### PR TITLE
feat(input-mapping): redesign finger-gun intent inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,13 @@
 # BalloonShoot
 
-`BalloonShoot` is a planned browser game prototype for after-school daycare use.
+`BalloonShoot` is a browser game prototype for after-school daycare use.
 
 The intended interaction is:
 
 - aim with the index finger
-- shoot with a thumb-trigger or pinch-like gesture
+- shoot with a thumb-trigger
 - pop floating balloons on screen
 
-The current repository state is pre-implementation. Project direction and constraints are captured in [docs/notes/2026-04-08-project-memo.md](docs/notes/2026-04-08-project-memo.md).
+The current repository state follows the issue-30 implementation contract. Project direction and constraints are captured in [docs/notes/2026-04-08-project-memo.md](docs/notes/2026-04-08-project-memo.md).
 
 For Codex remote/cloud preparation notes, see [docs/setup/codex-remote-setup.md](docs/setup/codex-remote-setup.md).
-

--- a/docs/superpowers/handovers/2026-04-08-implementation-session-handoff.md
+++ b/docs/superpowers/handovers/2026-04-08-implementation-session-handoff.md
@@ -4,9 +4,9 @@ Date: 2026-04-08
 
 ## Purpose
 
-This handoff is for the next Codex session that will start implementation work for the `BalloonShoot` PoC.
+This handoff is for the next Codex session that will review or continue the `BalloonShoot` PoC after the issue-30 implementation pass.
 
-The current session completed requirements/design alignment, wrote the formal PoC design, wrote the implementation plan, and ran external review passes on the design docs. No application code has been implemented yet.
+The current session completed requirements/design alignment, wrote the formal PoC design, wrote the implementation plan, implemented the issue-30 interaction contract, and ran external review passes on the design docs.
 
 ## Authoritative Documents
 
@@ -19,12 +19,23 @@ Read these first, in this order:
 
 ## Current Project State
 
-- Repository is still pre-implementation.
-- The implementation plan has been written but not executed.
+- Repository reflects the issue-30 implementation branch.
+- The implementation plan has been executed through the final docs alignment pass.
 - The PoC is Chrome-first.
 - Vanilla TypeScript + Canvas 2D is the chosen PoC stack.
 - MediaPipe Hand Landmarker is the chosen tracking stack.
 - The game core must stay reusable for a later Phaser migration.
+
+## Issue-30 Interaction Contract
+
+- Aim with the index finger.
+- Shoot with a loose gun pose plus a thumb-trigger open to pulled transition.
+- `pinch` is superseded and is not part of the PoC contract.
+- Gun-pose confidence uses a 0.55 entry threshold and a 0.45 exit threshold.
+- A low-confidence pulled frame can keep the visible pose armed while delaying fire until confidence recovers.
+- Reacquisition requires a fresh tracking-present frame before re-arming.
+- Tracking loss stays distinct from open-state behavior.
+- Debug-only telemetry exposes phase, reject reason, trigger confidence, gun-pose confidence, and counters.
 
 ## Fixed PoC Decisions
 
@@ -66,34 +77,30 @@ Latest committed history:
 - `695565f` `docs: add PoC foundation design`
 - `51f231f` `Initialize project docs and Codex remote setup`
 
-Current working tree is not clean. At the time of this handoff, these changes are uncommitted:
+Current working tree is not clean. At the time of this handoff, it contains the issue-30 implementation diff plus the Task 9 docs alignment edits.
 
-- modified: `docs/superpowers/specs/2026-04-08-poc-foundation-design.md`
-- untracked directory: `docs/superpowers/plans/`
+- modified tracked files include the issue-30 code path under `src/app/bootstrap/`, `src/features/debug/`, `src/features/input-mapping/`, `src/main.ts`, related tests, and the docs updates in `README.md` plus this handoff
+- untracked paths include `.playwright-mcp/`, `.sisyphus/`, `src/features/input-mapping/createHandEvidence.ts`, `src/features/input-mapping/shotIntentStateMachine.ts`, `test-results/`, and the new issue-30 test files
 
-This is expected. The current session added the implementation plan and a final design-note update that `AGENTS.md` files must be written in English.
+This is expected while the branch remains in active implementation and verification.
+
+## Verification
+
+- Final verification for the issue-30 branch is green: `npm run lint && npm run typecheck && npm run test && npm run test:e2e`.
+- After this docs pass, `npm run typecheck` still passes.
 
 ## Recommended First Actions in the Next Session
 
-1. Review the uncommitted docs changes.
-2. Commit the handoff-related docs before starting code changes.
-3. Execute `Task 1` from `docs/superpowers/plans/2026-04-08-poc-implementation.md`.
+1. Review the issue-30 docs trail and verification notes.
+2. Use the spec and this handoff as the contract source for any follow-up review or delegation.
+3. If further code work is needed, start from the existing implementation and keep the thumb-trigger contract intact.
 4. Prefer the subagent-driven execution path if available.
 
 ## First Execution Target
 
-Start with `Task 1: Bootstrap the Repo and Enforce Quality Gates`.
+The initial bootstrap tasks are already complete.
 
-That task establishes:
-
-- Vite + TypeScript project bootstrap
-- strict TS config
-- strict ESLint config
-- Prettier config
-- Vitest and Playwright setup
-- initial smoke verification
-
-Do not skip directly to MediaPipe integration before the quality gates exist.
+Keep any future work scoped to the implemented contract, the debug surface, and issue-30 follow-up review.
 
 ## Notes for the Next Session
 

--- a/src/app/bootstrap/startApp.ts
+++ b/src/app/bootstrap/startApp.ts
@@ -6,10 +6,7 @@ import {
   type DebugValues
 } from "../../features/debug/createDebugPanel";
 import { createGameEngine, registerShot } from "../../features/gameplay/domain/createGameEngine";
-import {
-  createMediaPipeHandTracker,
-  type MediaPipeHandTracker
-} from "../../features/hand-tracking/createMediaPipeHandTracker";
+import { createMediaPipeHandTracker } from "../../features/hand-tracking/createMediaPipeHandTracker";
 import {
   mapHandToGameInput,
   type InputRuntimeState
@@ -23,12 +20,14 @@ import { createInitialAppState, reduceAppEvent } from "../state/reduceAppEvent";
 const CROSSHAIR_Y_RATIO = 0.62;
 
 export interface StartAppDebugHooks {
-  createHandTracker?: () => Promise<MediaPipeHandTracker>;
+  createHandTracker?: () => Promise<HandTrackerLike>;
 }
 
 interface ImageCaptureLike {
   grabFrame(): Promise<ImageBitmap>;
 }
+
+type HandTrackerLike = Pick<Awaited<ReturnType<typeof createMediaPipeHandTracker>>, "detect">;
 
 type ImageCaptureConstructorLike = new (track: MediaStreamTrack) => ImageCaptureLike;
 

--- a/src/app/bootstrap/startApp.ts
+++ b/src/app/bootstrap/startApp.ts
@@ -296,6 +296,8 @@ export const startApp = (
           debugPanel.values
         );
 
+        const previousTrackedCrosshair = trackedCrosshair;
+
         inputRuntime = input.runtime;
         trackedCrosshair = input.crosshair;
         debugPanel.setTelemetry(toDebugTelemetry(input.runtime));
@@ -308,7 +310,7 @@ export const startApp = (
           void audio?.playShot().catch(logAudioPlaybackFailure("Shot"));
 
           const scoreBefore = engine.score;
-          const shotCrosshair = input.crosshair ?? trackedCrosshair;
+          const shotCrosshair = input.crosshair ?? previousTrackedCrosshair;
 
           if (shotCrosshair) {
             registerShot(engine, {

--- a/src/app/bootstrap/startApp.ts
+++ b/src/app/bootstrap/startApp.ts
@@ -153,7 +153,6 @@ export const startApp = (
     debugRoot.querySelectorAll<HTMLElement>("[data-debug-output]")
   );
 
-
   const ctx = canvas.getContext("2d");
 
   if (!ctx) {
@@ -413,15 +412,16 @@ export const startApp = (
         return;
       }
 
-      state = nextState;
-      stopGameLoop();
-      inputRuntime = undefined;
-      trackedCrosshair = undefined;
-      engine = createGameEngine();
-      void audio?.startBgm().catch(logAudioPlaybackFailure("BGM"));
-      startTrackerLoop();
-      startCountdown();
-      return;
+    state = nextState;
+    stopGameLoop();
+    inputRuntime = undefined;
+    trackedCrosshair = undefined;
+    debugPanel.setTelemetry(undefined);
+    engine = createGameEngine();
+    void audio?.startBgm().catch(logAudioPlaybackFailure("BGM"));
+    startTrackerLoop();
+    startCountdown();
+    return;
     }
 
     if (event.type === "RETRY_CLICKED") {
@@ -439,6 +439,7 @@ export const startApp = (
       publishCameraFeedStream(undefined);
       inputRuntime = undefined;
       trackedCrosshair = undefined;
+      debugPanel.setTelemetry(undefined);
       engine = createGameEngine();
       state = nextState;
       render();

--- a/src/app/bootstrap/startApp.ts
+++ b/src/app/bootstrap/startApp.ts
@@ -1,8 +1,15 @@
 import { createAudioController, type AudioController } from "../../features/audio/createAudioController";
 import { createCameraController, type CameraController } from "../../features/camera/createCameraController";
-import { createDebugPanel, type DebugValues } from "../../features/debug/createDebugPanel";
+import {
+  createDebugPanel,
+  type DebugTelemetry,
+  type DebugValues
+} from "../../features/debug/createDebugPanel";
 import { createGameEngine, registerShot } from "../../features/gameplay/domain/createGameEngine";
-import { createMediaPipeHandTracker } from "../../features/hand-tracking/createMediaPipeHandTracker";
+import {
+  createMediaPipeHandTracker,
+  type MediaPipeHandTracker
+} from "../../features/hand-tracking/createMediaPipeHandTracker";
 import {
   mapHandToGameInput,
   type InputRuntimeState
@@ -14,6 +21,10 @@ import type { AppEvent } from "../state/appState";
 import { createInitialAppState, reduceAppEvent } from "../state/reduceAppEvent";
 
 const CROSSHAIR_Y_RATIO = 0.62;
+
+export interface StartAppDebugHooks {
+  createHandTracker?: () => Promise<MediaPipeHandTracker>;
+}
 
 interface ImageCaptureLike {
   grabFrame(): Promise<ImageBitmap>;
@@ -33,18 +44,25 @@ const publishCameraFeedStream = (stream: MediaStream | undefined): void => {
 
 export const getCameraFeedStream = (): MediaStream | undefined => cameraFeedStream;
 
-export const setCameraFeedStreamListener = (
-  listener: CameraFeedListener | undefined
-): void => {
-  cameraFeedListener = listener;
-  listener?.(cameraFeedStream);
-};
-
-export const createDefaultDebugValues = (): DebugValues => ({
+const createDefaultDebugValues = (): DebugValues => ({
   smoothingAlpha: gameConfig.input.smoothingAlpha,
   triggerPullThreshold: gameConfig.input.triggerPullThreshold,
   triggerReleaseThreshold: gameConfig.input.triggerReleaseThreshold
 });
+
+const toDebugTelemetry = (runtime: InputRuntimeState | undefined): DebugTelemetry | undefined =>
+  runtime
+    ? {
+        phase: runtime.phase,
+        rejectReason: runtime.rejectReason,
+        triggerConfidence: runtime.triggerConfidence,
+        gunPoseConfidence: runtime.gunPoseConfidence,
+        openFrames: runtime.openFrames,
+        pulledFrames: runtime.pulledFrames,
+        trackingPresentFrames: runtime.trackingPresentFrames,
+        nonGunPoseFrames: runtime.nonGunPoseFrames
+      }
+    : undefined;
 
 const createImageCapture = (stream: MediaStream): ImageCaptureLike => {
   const ImageCaptureApi = (
@@ -84,14 +102,16 @@ export const resolveOverlayAction = (
 
 export const startApp = (
   root: HTMLDivElement,
-  debugValues: DebugValues = createDefaultDebugValues()
+  debugValues: DebugValues = createDefaultDebugValues(),
+  debugHooks?: StartAppDebugHooks
 ): void => {
   let state = createInitialAppState();
   let engine = createGameEngine();
   let audio: AudioController | undefined;
   let camera: CameraController | undefined;
   let countdownTimerId: number | undefined;
-  let trackerPromise: ReturnType<typeof createMediaPipeHandTracker> | undefined;
+  const createHandTracker = debugHooks?.createHandTracker ?? createMediaPipeHandTracker;
+  let trackerPromise: ReturnType<typeof createHandTracker> | undefined;
   let gameFrameRequestId: number | undefined;
   let trackingFrameRequestId: number | undefined;
   let trackingCapture: ImageCaptureLike | undefined;
@@ -128,7 +148,10 @@ export const startApp = (
 
   const debugPanel = createDebugPanel(debugValues);
   debugRoot.innerHTML = debugPanel.render();
-  debugPanel.bind(debugRoot.querySelectorAll<HTMLInputElement>("[data-debug]"));
+  debugPanel.bind(
+    debugRoot.querySelectorAll<HTMLInputElement>("[data-debug]"),
+    debugRoot.querySelectorAll<HTMLElement>("[data-debug-output]")
+  );
 
 
   const ctx = canvas.getContext("2d");
@@ -185,17 +208,21 @@ export const startApp = (
     trackerPromise = undefined;
     inputRuntime = undefined;
     trackedCrosshair = undefined;
+    debugPanel.setTelemetry(undefined);
     engine = createGameEngine();
     state = createInitialAppState();
     console.error("Camera startup failed", error);
     render();
   };
 
-  const getTrackerPromise = (): ReturnType<typeof createMediaPipeHandTracker> =>
-    (trackerPromise ??= createMediaPipeHandTracker().catch((error: unknown) => {
-      trackerPromise = undefined;
-      throw error;
-    }));
+  const getTrackerPromise = (): ReturnType<typeof createHandTracker> => {
+    trackerPromise ??= createHandTracker().catch((error: unknown) => {
+        trackerPromise = undefined;
+        throw error;
+      });
+
+    return trackerPromise;
+  };
 
   const syncScore = (): void => {
     state = reduceAppEvent(state, {
@@ -208,18 +235,20 @@ export const startApp = (
 
   const render = (): void => {
     overlayRoot.innerHTML = renderShell(state);
+    const crosshair =
+      state.screen === "playing"
+        ? inputRuntime?.phase === "tracking_lost"
+          ? undefined
+          : trackedCrosshair ??
+            inputRuntime?.crosshair ?? {
+              x: canvas.width / 2,
+              y: canvas.height * CROSSHAIR_Y_RATIO
+            }
+        : undefined;
+
     drawGameFrame(ctx, {
       balloons: engine.balloons,
-      ...(state.screen === "playing"
-        ? {
-            crosshair:
-              trackedCrosshair ??
-              inputRuntime?.crosshair ?? {
-                x: canvas.width / 2,
-                y: canvas.height * CROSSHAIR_Y_RATIO
-              }
-          }
-        : {})
+      ...(crosshair === undefined ? {} : { crosshair })
     });
   };
 
@@ -261,10 +290,6 @@ export const startApp = (
       try {
         const handFrame = await tracker.detect(bitmap, frameAtMs);
 
-        if (!handFrame) {
-          return;
-        }
-
         const input = mapHandToGameInput(
           handFrame,
           { width: canvas.width, height: canvas.height },
@@ -274,17 +299,26 @@ export const startApp = (
 
         inputRuntime = input.runtime;
         trackedCrosshair = input.crosshair;
+        debugPanel.setTelemetry(toDebugTelemetry(input.runtime));
+
+        if (input.runtime.phase === "tracking_lost") {
+          render();
+        }
 
         if (input.shotFired) {
           void audio?.playShot().catch(logAudioPlaybackFailure("Shot"));
 
           const scoreBefore = engine.score;
-          registerShot(engine, {
-            x: input.crosshair.x,
-            y: input.crosshair.y,
-            // `hit: true` opts this shot into collision detection inside the engine.
-            hit: true
-          });
+          const shotCrosshair = input.crosshair ?? trackedCrosshair;
+
+          if (shotCrosshair) {
+            registerShot(engine, {
+              x: shotCrosshair.x,
+              y: shotCrosshair.y,
+              // `hit: true` opts this shot into collision detection inside the engine.
+              hit: true
+            });
+          }
 
           if (engine.score > scoreBefore) {
             void audio?.playHit().catch(logAudioPlaybackFailure("Hit"));

--- a/src/features/debug/createDebugPanel.ts
+++ b/src/features/debug/createDebugPanel.ts
@@ -11,10 +11,30 @@ export interface DebugInputElement {
   addEventListener(type: "input", listener: () => void): void;
 }
 
+export interface DebugOutputElement {
+  dataset: { debugOutput?: string };
+  textContent: string | null;
+}
+
+export interface DebugTelemetry {
+  phase: string;
+  rejectReason: string;
+  triggerConfidence: number;
+  gunPoseConfidence: number;
+  openFrames: number;
+  pulledFrames: number;
+  trackingPresentFrames: number;
+  nonGunPoseFrames: number;
+}
+
 export interface DebugPanel {
   readonly values: DebugValues;
   render(): string;
-  bind(inputs: Iterable<DebugInputElement>): void;
+  bind(
+    inputs: Iterable<DebugInputElement>,
+    outputs?: Iterable<DebugOutputElement>
+  ): void;
+  setTelemetry(telemetry: DebugTelemetry | undefined): void;
 }
 
 interface DebugControlMeta {
@@ -23,6 +43,8 @@ interface DebugControlMeta {
   max: number;
   step: number;
 }
+
+type DebugOutputKey = "phase" | "rejectReason" | "trigger" | "gunPose" | "counters";
 
 const HYSTERESIS_GAP = 0.01;
 
@@ -39,6 +61,16 @@ const DEBUG_META: Record<keyof DebugValues, DebugControlMeta> = {
   triggerPullThreshold: { label: "Pull", min: 0.05, max: 0.4, step: 0.01 },
   triggerReleaseThreshold: { label: "Release", min: 0.02, max: 0.25, step: 0.01 }
 };
+
+const DEBUG_OUTPUT_META: Record<DebugOutputKey, string> = {
+  phase: "Phase",
+  rejectReason: "Reject",
+  trigger: "Trigger",
+  gunPose: "Pose",
+  counters: "Counts"
+};
+
+const DEBUG_OUTPUT_KEYS = Object.keys(DEBUG_OUTPUT_META) as DebugOutputKey[];
 
 const isDebugKey = (key: string | undefined): key is keyof DebugValues =>
   key !== undefined && DEBUG_KEY_SET.has(key);
@@ -59,6 +91,34 @@ const countDecimals = (value: number): number => {
 
 const formatForInput = (key: keyof DebugValues, value: number): string =>
   String(Number(value.toFixed(countDecimals(DEBUG_META[key].step))));
+
+const formatConfidence = (value: number | undefined): string =>
+  Number.isFinite(value) ? Number(value).toFixed(2) : "--";
+
+const formatTelemetryOutput = (
+  key: DebugOutputKey,
+  telemetry: DebugTelemetry | undefined
+): string => {
+  if (!telemetry) {
+    return key === "counters" ? "open=0 pull=0 track=0 pose=0" : "--";
+  }
+
+  switch (key) {
+    case "phase":
+      return telemetry.phase;
+    case "rejectReason":
+      return telemetry.rejectReason;
+    case "trigger":
+      return formatConfidence(telemetry.triggerConfidence);
+    case "gunPose":
+      return formatConfidence(telemetry.gunPoseConfidence);
+    case "counters":
+      return `open=${String(telemetry.openFrames)} pull=${String(telemetry.pulledFrames)} track=${String(telemetry.trackingPresentFrames)} pose=${String(telemetry.nonGunPoseFrames)}`;
+  }
+};
+
+const isDebugOutputKey = (key: string | undefined): key is DebugOutputKey =>
+  key !== undefined && DEBUG_OUTPUT_KEYS.includes(key as DebugOutputKey);
 
 const normalizeTriggerThresholds = (
   triggerPullThreshold: number,
@@ -85,6 +145,8 @@ export const createDebugPanel = (initial: DebugValues): DebugPanel => {
     )
   };
   const boundInputs: Partial<Record<keyof DebugValues, DebugInputElement>> = {};
+  const boundOutputs: Partial<Record<DebugOutputKey, DebugOutputElement>> = {};
+  let telemetry: DebugTelemetry | undefined;
 
   const renderRow = (key: keyof DebugValues): string => {
     const meta = DEBUG_META[key];
@@ -93,7 +155,11 @@ export const createDebugPanel = (initial: DebugValues): DebugPanel => {
 
   const render = (): string => {
     const rows = DEBUG_KEYS.map(renderRow).join("");
-    return `<aside class="debug-panel" aria-label="debug controls">${rows}</aside>`;
+    const telemetryRows = DEBUG_OUTPUT_KEYS.map(
+      (key) =>
+        `<div class="debug-panel-row"><span>${DEBUG_OUTPUT_META[key]}</span><output data-debug-output="${key}">${formatTelemetryOutput(key, telemetry)}</output></div>`
+    ).join("");
+    return `<aside class="debug-panel" aria-label="debug controls">${rows}${telemetryRows}</aside>`;
   };
 
   const syncInputValue = (key: keyof DebugValues): void => {
@@ -117,7 +183,28 @@ export const createDebugPanel = (initial: DebugValues): DebugPanel => {
     syncInputValue("triggerReleaseThreshold");
   };
 
-  const bind = (inputs: Iterable<DebugInputElement>): void => {
+  const syncTelemetryOutput = (key: DebugOutputKey): void => {
+    const output = boundOutputs[key];
+
+    if (!output) {
+      return;
+    }
+
+    output.textContent = formatTelemetryOutput(key, telemetry);
+  };
+
+  const setTelemetry = (nextTelemetry: DebugTelemetry | undefined): void => {
+    telemetry = nextTelemetry;
+
+    for (const key of DEBUG_OUTPUT_KEYS) {
+      syncTelemetryOutput(key);
+    }
+  };
+
+  const bind = (
+    inputs: Iterable<DebugInputElement>,
+    outputs: Iterable<DebugOutputElement> = []
+  ): void => {
     for (const input of inputs) {
       const boundKey = input.dataset.debug;
 
@@ -146,7 +233,18 @@ export const createDebugPanel = (initial: DebugValues): DebugPanel => {
         }
       });
     }
+
+    for (const output of outputs) {
+      const key = output.dataset.debugOutput;
+
+      if (!isDebugOutputKey(key)) {
+        continue;
+      }
+
+      boundOutputs[key] = output;
+      syncTelemetryOutput(key);
+    }
   };
 
-  return { values, render, bind };
+  return { values, render, bind, setTelemetry };
 };

--- a/src/features/input-mapping/createHandEvidence.ts
+++ b/src/features/input-mapping/createHandEvidence.ts
@@ -1,0 +1,75 @@
+import { gameConfig } from "../../shared/config/gameConfig";
+import type { HandFrame } from "../../shared/types/hand";
+import {
+  smoothCrosshair,
+  type CrosshairPoint
+} from "./createCrosshairSmoother";
+import {
+  measureGunPose,
+  type GunPoseMeasurement
+} from "./evaluateGunPose";
+import {
+  measureThumbTrigger,
+  type ThumbTriggerMeasurement,
+  type TriggerState,
+  type TriggerTuning
+} from "./evaluateThumbTrigger";
+import type { ViewportSize } from "./projectLandmarkToViewport";
+import { projectLandmarkToViewport } from "./projectLandmarkToViewport";
+
+interface HandEvidenceRuntimeState {
+  crosshair?: CrosshairPoint | undefined;
+  rawTriggerState?: TriggerState | undefined;
+}
+
+export interface HandEvidenceTuning extends TriggerTuning {
+  smoothingAlpha: number;
+}
+
+export interface HandEvidence {
+  trackingPresent: boolean;
+  frameAtMs: number | undefined;
+  smoothedCrosshairCandidate: CrosshairPoint | null;
+  trigger: ThumbTriggerMeasurement | null;
+  gunPose: GunPoseMeasurement | null;
+}
+
+export const buildHandEvidence = (
+  frame: HandFrame | undefined,
+  viewportSize: ViewportSize,
+  runtime: HandEvidenceRuntimeState | undefined,
+  frameAtMs?: number,
+  tuning: HandEvidenceTuning = gameConfig.input
+): HandEvidence => {
+  if (!frame) {
+    return {
+      trackingPresent: false,
+      frameAtMs,
+      smoothedCrosshairCandidate: null,
+      trigger: null,
+      gunPose: null
+    };
+  }
+
+  const projectedCrosshair = projectLandmarkToViewport(
+    frame.landmarks.indexTip,
+    { width: frame.width, height: frame.height },
+    viewportSize,
+    { mirrorX: true }
+  );
+  const smoothedCrosshairCandidate = smoothCrosshair(
+    runtime?.crosshair,
+    projectedCrosshair,
+    tuning.smoothingAlpha
+  );
+  const trigger = measureThumbTrigger(frame, runtime?.rawTriggerState, tuning);
+  const gunPose = measureGunPose(frame);
+
+  return {
+    trackingPresent: true,
+    frameAtMs,
+    smoothedCrosshairCandidate,
+    trigger,
+    gunPose
+  };
+};

--- a/src/features/input-mapping/evaluateGunPose.ts
+++ b/src/features/input-mapping/evaluateGunPose.ts
@@ -1,12 +1,37 @@
 import type { HandFrame } from "../../shared/types/hand";
 
-export const evaluateGunPose = (frame: HandFrame): boolean => {
+export interface GunPoseMeasurement {
+  detected: boolean;
+  confidence: number;
+  details: {
+    indexExtended: boolean;
+    curledFingerCount: number;
+    curledThreshold: number;
+  };
+}
+
+export const measureGunPose = (frame: HandFrame): GunPoseMeasurement => {
   const { wrist, indexTip, indexMcp, middleTip, ringTip, pinkyTip } = frame.landmarks;
   const handScale = Math.hypot(indexMcp.x - wrist.x, indexMcp.y - wrist.y) || 1;
   const curledThreshold = handScale * 0.25;
-
   const indexExtended = indexTip.y < indexMcp.y;
-  const curledFingers = [middleTip, ringTip, pinkyTip].filter((point) => point.y > indexMcp.y + curledThreshold).length;
+  const curledFingerCount = [middleTip, ringTip, pinkyTip].filter(
+    (point) => point.y > indexMcp.y + curledThreshold
+  ).length;
+  const detected = indexExtended && curledFingerCount >= 2;
+  const confidence = indexExtended ? Math.min(1, 0.5 + (curledFingerCount / 6)) : 0;
 
-  return indexExtended && curledFingers >= 2;
+  return {
+    detected,
+    confidence,
+    details: {
+      indexExtended,
+      curledFingerCount,
+      curledThreshold
+    }
+  };
+};
+
+export const evaluateGunPose = (frame: HandFrame): boolean => {
+  return measureGunPose(frame).detected;
 };

--- a/src/features/input-mapping/evaluateGunPose.ts
+++ b/src/features/input-mapping/evaluateGunPose.ts
@@ -1,5 +1,7 @@
 import type { HandFrame } from "../../shared/types/hand";
 
+const FIRE_ENTRY_GUN_POSE_CONFIDENCE = 0.55;
+
 export interface GunPoseMeasurement {
   detected: boolean;
   confidence: number;
@@ -19,7 +21,10 @@ export const measureGunPose = (frame: HandFrame): GunPoseMeasurement => {
     (point) => point.y > indexMcp.y + curledThreshold
   ).length;
   const detected = indexExtended && curledFingerCount >= 2;
-  const confidence = indexExtended ? Math.min(1, 0.5 + (curledFingerCount / 6)) : 0;
+  const rawConfidence = indexExtended ? Math.min(1, 0.5 + curledFingerCount / 6) : 0;
+  const confidence = detected
+    ? rawConfidence
+    : Math.min(rawConfidence, FIRE_ENTRY_GUN_POSE_CONFIDENCE - Number.EPSILON);
 
   return {
     detected,

--- a/src/features/input-mapping/evaluateThumbTrigger.ts
+++ b/src/features/input-mapping/evaluateThumbTrigger.ts
@@ -3,6 +3,16 @@ import { gameConfig } from "../../shared/config/gameConfig";
 
 export type TriggerState = "open" | "pulled";
 
+export interface ThumbTriggerMeasurement {
+  rawState: TriggerState;
+  confidence: number;
+  details: {
+    projection: number;
+    pullThreshold: number;
+    releaseThreshold: number;
+  };
+}
+
 export interface TriggerTuning {
   triggerPullThreshold: number;
   triggerReleaseThreshold: number;
@@ -40,17 +50,47 @@ const normalizeTriggerTuning = (tuning: TriggerTuning): TriggerTuning => {
   };
 };
 
+const clamp01 = (value: number): number => Math.min(1, Math.max(0, value));
+
+export const measureThumbTrigger = (
+  frame: HandFrame,
+  previousState: TriggerState | undefined,
+  tuning: TriggerTuning = gameConfig.input
+): ThumbTriggerMeasurement => {
+  const thumbPull = measureThumbPull(frame);
+  const safeTuning = normalizeTriggerTuning(tuning);
+  const rawState =
+    previousState === "pulled"
+      ? thumbPull > safeTuning.triggerReleaseThreshold
+        ? "pulled"
+        : "open"
+      : thumbPull > safeTuning.triggerPullThreshold
+        ? "pulled"
+        : "open";
+  const confidenceRange = Math.max(
+    safeTuning.triggerPullThreshold - safeTuning.triggerReleaseThreshold,
+    Number.EPSILON
+  );
+  const confidence =
+    rawState === "pulled"
+      ? clamp01((thumbPull - safeTuning.triggerReleaseThreshold) / confidenceRange)
+      : clamp01((safeTuning.triggerPullThreshold - thumbPull) / confidenceRange);
+
+  return {
+    rawState,
+    confidence,
+    details: {
+      projection: thumbPull,
+      pullThreshold: safeTuning.triggerPullThreshold,
+      releaseThreshold: safeTuning.triggerReleaseThreshold
+    }
+  };
+};
+
 export const evaluateThumbTrigger = (
   frame: HandFrame,
   previousState: TriggerState | undefined,
   tuning: TriggerTuning = gameConfig.input
 ): TriggerState => {
-  const thumbPull = measureThumbPull(frame);
-  const safeTuning = normalizeTriggerTuning(tuning);
-
-  if (previousState === "pulled") {
-    return thumbPull > safeTuning.triggerReleaseThreshold ? "pulled" : "open";
-  }
-
-  return thumbPull > safeTuning.triggerPullThreshold ? "pulled" : "open";
+  return measureThumbTrigger(frame, previousState, tuning).rawState;
 };

--- a/src/features/input-mapping/mapHandToGameInput.ts
+++ b/src/features/input-mapping/mapHandToGameInput.ts
@@ -1,34 +1,20 @@
 import { gameConfig } from "../../shared/config/gameConfig";
 import type { HandFrame } from "../../shared/types/hand";
-import { smoothCrosshair, type CrosshairPoint } from "./createCrosshairSmoother";
-import { evaluateGunPose } from "./evaluateGunPose";
+import type { CrosshairPoint } from "./createCrosshairSmoother";
+import { buildHandEvidence, type HandEvidenceTuning } from "./createHandEvidence";
 import {
-  projectLandmarkToViewport,
-  type ViewportSize
-} from "./projectLandmarkToViewport";
-import {
-  evaluateThumbTrigger,
-  type TriggerState,
-  type TriggerTuning
-} from "./evaluateThumbTrigger";
+  advanceShotIntentState,
+  type ShotIntentState
+} from "./shotIntentStateMachine";
+import type { ViewportSize } from "./projectLandmarkToViewport";
+import { type TriggerState, type TriggerTuning } from "./evaluateThumbTrigger";
 
-const TRIGGER_CONFIRMATION_FRAMES = 2;
-const TRIGGER_RELEASE_FRAMES = 2;
-const GUN_POSE_GRACE_FRAMES = 1;
-
-export interface InputRuntimeState {
-  crosshair?: CrosshairPoint;
-  triggerState: TriggerState;
-  rawTriggerState: TriggerState;
-  pulledFrames: number;
-  openFrames: number;
-  hasSeenStableOpen: boolean;
-  gunPoseActive: boolean;
-  nonGunPoseFrames: number;
+export interface InputRuntimeState extends ShotIntentState {
+  crosshair?: CrosshairPoint | undefined;
 }
 
 export interface GameInputFrame {
-  crosshair: CrosshairPoint;
+  crosshair?: CrosshairPoint;
   gunPoseActive: boolean;
   triggerState: TriggerState;
   shotFired: boolean;
@@ -39,59 +25,70 @@ export interface InputTuning extends TriggerTuning {
   smoothingAlpha: number;
 }
 
+export { buildHandEvidence } from "./createHandEvidence";
+
+const resolveHandEvidence = (
+  frame: HandFrame | undefined,
+  viewportSize: ViewportSize,
+  runtime: InputRuntimeState | undefined,
+  tuning: InputTuning
+): ReturnType<typeof buildHandEvidence> =>
+  buildHandEvidence(
+    frame,
+    viewportSize,
+    {
+      crosshair: runtime?.crosshair,
+      rawTriggerState: runtime?.rawTriggerState
+    },
+    undefined,
+    tuning as HandEvidenceTuning
+  );
+
+const inferShotIntent = (
+  runtime: InputRuntimeState | undefined,
+  evidence: ReturnType<typeof buildHandEvidence>
+): ReturnType<typeof advanceShotIntentState> => advanceShotIntentState(runtime, evidence);
+
+const dropRuntimeCrosshair = (
+  state: InputRuntimeState
+): Omit<InputRuntimeState, "crosshair"> => {
+  const { crosshair: _previousCrosshair, ...runtimeState } = state;
+
+  return runtimeState;
+};
+
+const adaptGameInputFrame = (
+  evidence: ReturnType<typeof buildHandEvidence>,
+  intent: ReturnType<typeof advanceShotIntentState>
+): GameInputFrame => {
+  const crosshair =
+    intent.state.phase === "tracking_lost"
+      ? undefined
+      : evidence.smoothedCrosshairCandidate ?? { x: 0, y: 0 };
+
+  return {
+    gunPoseActive: intent.state.gunPoseActive,
+    triggerState: intent.state.triggerState,
+    shotFired: intent.shotFired,
+    ...(crosshair === undefined ? {} : { crosshair }),
+    // `advanceShotIntentState` preserves prior runtime fields, so drop any stale crosshair
+    // before attaching the current one.
+    runtime: {
+      ...dropRuntimeCrosshair(intent.state as InputRuntimeState),
+      rejectReason: intent.state.rejectReason,
+      ...(crosshair === undefined ? {} : { crosshair })
+    }
+  };
+};
+
 export const mapHandToGameInput = (
-  frame: HandFrame,
+  frame: HandFrame | undefined,
   viewportSize: ViewportSize,
   runtime: InputRuntimeState | undefined,
   tuning: InputTuning = gameConfig.input
 ): GameInputFrame => {
-  const rawCrosshair = projectLandmarkToViewport(
-    frame.landmarks.indexTip,
-    { width: frame.width, height: frame.height },
-    viewportSize,
-    { mirrorX: true }
-  );
-  const crosshair = smoothCrosshair(runtime?.crosshair, rawCrosshair, tuning.smoothingAlpha);
-  const previousTriggerState = runtime?.triggerState ?? "open";
-  const previousRawTriggerState = runtime?.rawTriggerState ?? previousTriggerState;
-  const rawTriggerState = evaluateThumbTrigger(frame, previousRawTriggerState, tuning);
-  const pulledFrames =
-    rawTriggerState === "pulled" ? (runtime?.pulledFrames ?? 0) + 1 : 0;
-  const openFrames = rawTriggerState === "open" ? (runtime?.openFrames ?? 0) + 1 : 0;
-  let triggerState = previousTriggerState;
+  const evidence = resolveHandEvidence(frame, viewportSize, runtime, tuning);
+  const intent = inferShotIntent(runtime, evidence);
 
-  if (previousTriggerState === "open" && pulledFrames >= TRIGGER_CONFIRMATION_FRAMES) {
-    triggerState = "pulled";
-  } else if (previousTriggerState === "pulled" && openFrames >= TRIGGER_RELEASE_FRAMES) {
-    triggerState = "open";
-  }
-
-  const hasSeenStableOpen =
-    openFrames >= TRIGGER_RELEASE_FRAMES || runtime?.hasSeenStableOpen === true;
-
-  const rawGunPoseActive = evaluateGunPose(frame);
-  const nonGunPoseFrames = rawGunPoseActive ? 0 : (runtime?.nonGunPoseFrames ?? 0) + 1;
-  const previousGunPoseActive = runtime?.gunPoseActive ?? false;
-  const gunPoseActive =
-    rawGunPoseActive ||
-    (previousGunPoseActive && nonGunPoseFrames <= GUN_POSE_GRACE_FRAMES);
-  const stablePullStarted = previousTriggerState === "open" && triggerState === "pulled";
-  const shotFired = hasSeenStableOpen && gunPoseActive && stablePullStarted;
-
-  return {
-    crosshair,
-    gunPoseActive,
-    triggerState,
-    shotFired,
-    runtime: {
-      crosshair,
-      triggerState,
-      rawTriggerState,
-      pulledFrames,
-      openFrames,
-      hasSeenStableOpen,
-      gunPoseActive,
-      nonGunPoseFrames
-    }
-  };
+  return adaptGameInputFrame(evidence, intent);
 };

--- a/src/features/input-mapping/shotIntentStateMachine.ts
+++ b/src/features/input-mapping/shotIntentStateMachine.ts
@@ -1,0 +1,420 @@
+import type { HandEvidence } from "./createHandEvidence";
+import type { TriggerState } from "./evaluateThumbTrigger";
+
+export type ShotIntentPhase =
+  | "idle"
+  | "tracking_lost"
+  | "ready"
+  | "armed"
+  | "fired"
+  | "recovering";
+
+export type ShotIntentRejectReason =
+  | "waiting_for_stable_open"
+  | "waiting_for_fire_entry"
+  | "waiting_for_stable_pulled"
+  | "waiting_for_release"
+  | "tracking_lost";
+
+export interface ShotIntentState {
+  phase: ShotIntentPhase;
+  rejectReason: ShotIntentRejectReason;
+  triggerState: TriggerState;
+  rawTriggerState: TriggerState;
+  triggerConfidence: number;
+  gunPoseConfidence: number;
+  pulledFrames: number;
+  openFrames: number;
+  hasSeenStableOpen: boolean;
+  gunPoseActive: boolean;
+  nonGunPoseFrames: number;
+  trackingPresentFrames: number;
+}
+
+export interface ShotIntentResult {
+  state: ShotIntentState;
+  shotFired: boolean;
+}
+
+const FIRE_ENTRY_GUN_POSE_CONFIDENCE = 0.55;
+const FIRE_EXIT_GUN_POSE_CONFIDENCE = 0.45;
+const GUN_POSE_GRACE_FRAMES = 1;
+const TRIGGER_CONFIRMATION_FRAMES = 2;
+const TRIGGER_RELEASE_FRAMES = 2;
+const TRACKING_RECOVERY_FRAMES = 2;
+
+const createInitialShotIntentState = (): ShotIntentState => ({
+  phase: "idle",
+  rejectReason: "waiting_for_stable_open",
+  triggerState: "open",
+  rawTriggerState: "open",
+  triggerConfidence: 0,
+  gunPoseConfidence: 0,
+  pulledFrames: 0,
+  openFrames: 0,
+  hasSeenStableOpen: false,
+  gunPoseActive: false,
+  nonGunPoseFrames: 0,
+  trackingPresentFrames: 0
+});
+
+const resolveGunPoseActive = (
+  evidence: HandEvidence,
+  previousState: ShotIntentState
+): { gunPoseActive: boolean; nonGunPoseFrames: number; gunPoseConfidence: number } => {
+  const gunPoseConfidence = evidence.gunPose?.confidence ?? 0;
+
+  if (!evidence.trackingPresent) {
+    return {
+      gunPoseActive: false,
+      nonGunPoseFrames: 0,
+      gunPoseConfidence
+    };
+  }
+
+  if (gunPoseConfidence >= FIRE_ENTRY_GUN_POSE_CONFIDENCE) {
+    return {
+      gunPoseActive: true,
+      nonGunPoseFrames: 0,
+      gunPoseConfidence
+    };
+  }
+
+  if (previousState.gunPoseActive && gunPoseConfidence >= FIRE_EXIT_GUN_POSE_CONFIDENCE) {
+    return {
+      gunPoseActive: true,
+      nonGunPoseFrames: 0,
+      gunPoseConfidence
+    };
+  }
+
+  const nonGunPoseFrames = previousState.gunPoseActive
+    ? previousState.nonGunPoseFrames + 1
+    : 1;
+
+  return {
+    gunPoseActive: previousState.gunPoseActive && nonGunPoseFrames <= GUN_POSE_GRACE_FRAMES,
+    nonGunPoseFrames,
+    gunPoseConfidence
+  };
+};
+
+const resolveTriggerState = (
+  evidence: HandEvidence,
+  previousState: ShotIntentState
+): Pick<
+  ShotIntentState,
+  "triggerState" | "rawTriggerState" | "triggerConfidence" | "pulledFrames" | "openFrames"
+> => {
+  const rawTriggerState = evidence.trigger?.rawState ?? previousState.rawTriggerState;
+  const triggerConfidence = evidence.trigger?.confidence ?? 0;
+  const pulledFrames = rawTriggerState === "pulled" ? previousState.pulledFrames + 1 : 0;
+  const openFrames = rawTriggerState === "open" ? previousState.openFrames + 1 : 0;
+
+  let triggerState = previousState.triggerState;
+
+  if (
+    previousState.triggerState === "open" &&
+    rawTriggerState === "pulled" &&
+    pulledFrames >= TRIGGER_CONFIRMATION_FRAMES
+  ) {
+    triggerState = "pulled";
+  } else if (
+    previousState.triggerState === "pulled" &&
+    rawTriggerState === "open" &&
+    openFrames >= TRIGGER_RELEASE_FRAMES
+  ) {
+    triggerState = "open";
+  }
+
+  return {
+    triggerState,
+    rawTriggerState,
+    triggerConfidence,
+    pulledFrames,
+    openFrames
+  };
+};
+
+const resolveRejectReason = (phase: ShotIntentPhase): ShotIntentRejectReason => {
+  switch (phase) {
+    case "idle":
+      return "waiting_for_stable_open";
+    case "tracking_lost":
+      return "tracking_lost";
+    case "ready":
+      return "waiting_for_fire_entry";
+    case "armed":
+      return "waiting_for_stable_pulled";
+    case "fired":
+      return "waiting_for_release";
+    case "recovering":
+      return "waiting_for_release";
+  }
+};
+
+const withTrackingLossReset = (state: ShotIntentState): ShotIntentState => ({
+  ...state,
+  phase: "tracking_lost",
+  rejectReason: "tracking_lost",
+  triggerState: "open",
+  rawTriggerState: "open",
+  triggerConfidence: 0,
+  gunPoseConfidence: 0,
+  pulledFrames: 0,
+  openFrames: 0,
+  hasSeenStableOpen: false,
+  gunPoseActive: false,
+  nonGunPoseFrames: 0,
+  trackingPresentFrames: 0
+});
+
+const withPoseLossReset = (
+  state: ShotIntentState,
+  trackingPresentFrames: number,
+  nonGunPoseFrames: number,
+  triggerConfidence: number,
+  gunPoseConfidence: number
+): ShotIntentState => ({
+  ...state,
+  phase: "idle",
+  rejectReason: resolveRejectReason("idle"),
+  triggerState: "open",
+  rawTriggerState: "open",
+  triggerConfidence,
+  gunPoseConfidence,
+  pulledFrames: 0,
+  openFrames: 0,
+  hasSeenStableOpen: false,
+  gunPoseActive: false,
+  nonGunPoseFrames,
+  trackingPresentFrames
+});
+
+type TriggerStateResolution = ReturnType<typeof resolveTriggerState>;
+type GunPoseResolution = ReturnType<typeof resolveGunPoseActive>;
+
+const resolveTrackingLostState = (
+  stateBefore: ShotIntentState,
+  trackingPresentFrames: number,
+  triggerState: TriggerStateResolution,
+  gunPose: GunPoseResolution
+): ShotIntentResult => {
+  if (trackingPresentFrames < TRACKING_RECOVERY_FRAMES) {
+    return {
+      state: {
+        ...stateBefore,
+        phase: "tracking_lost",
+        rejectReason: "tracking_lost",
+        triggerState: triggerState.triggerState,
+        rawTriggerState: triggerState.rawTriggerState,
+        triggerConfidence: triggerState.triggerConfidence,
+        gunPoseConfidence: gunPose.gunPoseConfidence,
+        pulledFrames: triggerState.pulledFrames,
+        openFrames: triggerState.openFrames,
+        gunPoseActive: gunPose.gunPoseActive,
+        nonGunPoseFrames: gunPose.nonGunPoseFrames,
+        trackingPresentFrames
+      },
+      shotFired: false
+    };
+  }
+
+  return {
+    state: {
+      ...stateBefore,
+      phase: "idle",
+      rejectReason: resolveRejectReason("idle"),
+      triggerState: triggerState.triggerState,
+      rawTriggerState: triggerState.rawTriggerState,
+      triggerConfidence: triggerState.triggerConfidence,
+      gunPoseConfidence: gunPose.gunPoseConfidence,
+      pulledFrames: triggerState.pulledFrames,
+      openFrames: triggerState.openFrames,
+      hasSeenStableOpen: false,
+      gunPoseActive: gunPose.gunPoseActive,
+      nonGunPoseFrames: gunPose.nonGunPoseFrames,
+      trackingPresentFrames
+    },
+    shotFired: false
+  };
+};
+
+const buildTrackedState = (
+  stateBefore: ShotIntentState,
+  phase: ShotIntentPhase,
+  triggerState: TriggerStateResolution,
+  gunPose: GunPoseResolution,
+  trackingPresentFrames: number
+): ShotIntentState => ({
+  ...stateBefore,
+  phase,
+  rejectReason: resolveRejectReason(phase),
+  triggerState: triggerState.triggerState,
+  rawTriggerState: triggerState.rawTriggerState,
+  triggerConfidence: triggerState.triggerConfidence,
+  gunPoseConfidence: gunPose.gunPoseConfidence,
+  pulledFrames: triggerState.pulledFrames,
+  openFrames: triggerState.openFrames,
+  hasSeenStableOpen:
+    phase === "ready" || phase === "armed" || phase === "recovering" || stateBefore.hasSeenStableOpen,
+  gunPoseActive: gunPose.gunPoseActive,
+  nonGunPoseFrames: gunPose.nonGunPoseFrames,
+  trackingPresentFrames
+});
+
+const advanceIdlePhase = (
+  stateBefore: ShotIntentState,
+  trackingPresentFrames: number,
+  triggerState: TriggerStateResolution,
+  gunPose: GunPoseResolution,
+  gunPoseFireReady: boolean
+): ShotIntentResult => {
+  const trackingAndPoseReady =
+    trackingPresentFrames >= TRACKING_RECOVERY_FRAMES && gunPose.gunPoseActive && gunPoseFireReady;
+  const stableOpen = triggerState.triggerState === "open" && triggerState.openFrames >= 2;
+  const phase: ShotIntentPhase = trackingAndPoseReady && stableOpen ? "ready" : "idle";
+  const nextState = buildTrackedState(stateBefore, phase, triggerState, gunPose, trackingPresentFrames);
+
+  if (phase === "idle") {
+    nextState.hasSeenStableOpen = stateBefore.hasSeenStableOpen || (trackingAndPoseReady && stableOpen);
+  }
+
+  return {
+    state: nextState,
+    shotFired: false
+  };
+};
+
+const advanceReadyPhase = (
+  stateBefore: ShotIntentState,
+  trackingPresentFrames: number,
+  triggerState: TriggerStateResolution,
+  gunPose: GunPoseResolution,
+  gunPoseFireReady: boolean
+): ShotIntentResult => {
+  const trackingAndPoseReady =
+    trackingPresentFrames >= TRACKING_RECOVERY_FRAMES && gunPose.gunPoseActive && gunPoseFireReady;
+  const stableOpen = triggerState.triggerState === "open" && triggerState.openFrames >= 2;
+  const phase: ShotIntentPhase = trackingAndPoseReady && stableOpen ? "armed" : "ready";
+
+  return {
+    state: buildTrackedState(stateBefore, phase, triggerState, gunPose, trackingPresentFrames),
+    shotFired: false
+  };
+};
+
+const advanceArmedPhase = (
+  stateBefore: ShotIntentState,
+  trackingPresentFrames: number,
+  triggerState: TriggerStateResolution,
+  gunPose: GunPoseResolution,
+  gunPoseFireReady: boolean
+): ShotIntentResult => {
+  const trackingAndPoseReady =
+    trackingPresentFrames >= TRACKING_RECOVERY_FRAMES && gunPose.gunPoseActive && gunPoseFireReady;
+  const stablePulled = triggerState.triggerState === "pulled" && triggerState.pulledFrames >= 2;
+  const shotFired = trackingAndPoseReady && stablePulled;
+  const phase: ShotIntentPhase = shotFired ? "fired" : "armed";
+
+  return {
+    state: buildTrackedState(stateBefore, phase, triggerState, gunPose, trackingPresentFrames),
+    shotFired
+  };
+};
+
+const advanceFiredPhase = (
+  stateBefore: ShotIntentState,
+  trackingPresentFrames: number,
+  triggerState: TriggerStateResolution,
+  gunPose: GunPoseResolution
+): ShotIntentResult => ({
+  state: buildTrackedState(stateBefore, "recovering", triggerState, gunPose, trackingPresentFrames),
+  shotFired: false
+});
+
+const advanceRecoveringPhase = (
+  stateBefore: ShotIntentState,
+  trackingPresentFrames: number,
+  triggerState: TriggerStateResolution,
+  gunPose: GunPoseResolution,
+  gunPoseFireReady: boolean
+): ShotIntentResult => {
+  const trackingAndPoseReady =
+    trackingPresentFrames >= TRACKING_RECOVERY_FRAMES && gunPose.gunPoseActive && gunPoseFireReady;
+  const stableOpen = triggerState.triggerState === "open" && triggerState.openFrames >= 2;
+  const phase: ShotIntentPhase = trackingAndPoseReady && stableOpen ? "ready" : "recovering";
+
+  return {
+    state: buildTrackedState(stateBefore, phase, triggerState, gunPose, trackingPresentFrames),
+    shotFired: false
+  };
+};
+
+const advanceTrackedPhase = (
+  stateBefore: ShotIntentState,
+  trackingPresentFrames: number,
+  triggerState: TriggerStateResolution,
+  gunPose: GunPoseResolution,
+  gunPoseFireReady: boolean
+): ShotIntentResult => {
+  switch (stateBefore.phase) {
+    case "idle":
+      return advanceIdlePhase(stateBefore, trackingPresentFrames, triggerState, gunPose, gunPoseFireReady);
+    case "ready":
+      return advanceReadyPhase(stateBefore, trackingPresentFrames, triggerState, gunPose, gunPoseFireReady);
+    case "armed":
+      return advanceArmedPhase(stateBefore, trackingPresentFrames, triggerState, gunPose, gunPoseFireReady);
+    case "fired":
+      return advanceFiredPhase(stateBefore, trackingPresentFrames, triggerState, gunPose);
+    case "recovering":
+      return advanceRecoveringPhase(
+        stateBefore,
+        trackingPresentFrames,
+        triggerState,
+        gunPose,
+        gunPoseFireReady
+      );
+  }
+
+  throw new Error(`Unhandled shot intent phase: ${stateBefore.phase}`);
+};
+
+export const advanceShotIntentState = (
+  previousState: ShotIntentState | undefined,
+  evidence: HandEvidence
+): ShotIntentResult => {
+  const stateBefore = previousState ?? createInitialShotIntentState();
+
+  if (!evidence.trackingPresent) {
+    return {
+      state: withTrackingLossReset(stateBefore),
+      shotFired: false
+    };
+  }
+
+  const trackingPresentFrames = stateBefore.trackingPresentFrames + 1;
+  const triggerState = resolveTriggerState(evidence, stateBefore);
+  const gunPose = resolveGunPoseActive(evidence, stateBefore);
+  const gunPoseFireReady = (evidence.gunPose?.confidence ?? 0) >= FIRE_ENTRY_GUN_POSE_CONFIDENCE;
+  const poseLost = !gunPose.gunPoseActive && gunPose.nonGunPoseFrames > GUN_POSE_GRACE_FRAMES;
+
+  if (poseLost) {
+    return {
+      state: withPoseLossReset(
+        stateBefore,
+        trackingPresentFrames,
+        gunPose.nonGunPoseFrames,
+        triggerState.triggerConfidence,
+        gunPose.gunPoseConfidence
+      ),
+      shotFired: false
+    };
+  }
+
+  if (stateBefore.phase === "tracking_lost") {
+    return resolveTrackingLostState(stateBefore, trackingPresentFrames, triggerState, gunPose);
+  }
+
+  return advanceTrackedPhase(stateBefore, trackingPresentFrames, triggerState, gunPose, gunPoseFireReady);
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import "./styles/app.css";
-import { startApp } from "./app/bootstrap/startApp";
+import { startApp, type StartAppDebugHooks } from "./app/bootstrap/startApp";
 
 const appRoot = document.querySelector<HTMLDivElement>("#app");
 
@@ -7,4 +7,12 @@ if (!appRoot) {
   throw new Error("Missing #app root");
 }
 
-startApp(appRoot);
+const debugHooks = import.meta.env.DEV
+  ? (
+      window as Window & {
+        __balloonShootTestHooks?: StartAppDebugHooks;
+      }
+    ).__balloonShootTestHooks
+  : undefined;
+
+startApp(appRoot, undefined, debugHooks);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
 import "./styles/app.css";
+import { createMediaPipeHandTracker } from "./features/hand-tracking/createMediaPipeHandTracker";
 import { startApp, type StartAppDebugHooks } from "./app/bootstrap/startApp";
 
 const appRoot = document.querySelector<HTMLDivElement>("#app");
@@ -8,11 +9,17 @@ if (!appRoot) {
 }
 
 const debugHooks = import.meta.env.DEV
-  ? (
-      window as Window & {
-        __balloonShootTestHooks?: StartAppDebugHooks;
+  ? {
+      createHandTracker: () => {
+        const testHooks = (
+          window as Window & {
+            __balloonShootTestHooks?: StartAppDebugHooks;
+          }
+        ).__balloonShootTestHooks;
+
+        return testHooks?.createHandTracker() ?? createMediaPipeHandTracker();
       }
-    ).__balloonShootTestHooks
+    }
   : undefined;
 
 startApp(appRoot, undefined, debugHooks);

--- a/tests/e2e/issue30.acceptance.spec.ts
+++ b/tests/e2e/issue30.acceptance.spec.ts
@@ -40,7 +40,8 @@ const bootHarness = async (page: Page, frames: (HandFrame | undefined)[]): Promi
     ({ scriptedFrames }) => {
       const frames = scriptedFrames.slice();
       let detectCount = 0;
-      let intervalCallback: (() => void) | undefined;
+      const intervalCallbacks = new Map<number, () => void>();
+      let nextIntervalId = 1;
       const telemetryTimeline: TelemetrySnapshot[] = [];
       let telemetryObserver: MutationObserver | undefined;
       let snapshotScheduled = false;
@@ -74,20 +75,24 @@ const bootHarness = async (page: Page, frames: (HandFrame | undefined)[]): Promi
       Object.defineProperty(window, "setInterval", {
         configurable: true,
         value: (callback: TimerHandler) => {
-          intervalCallback = () => {
+          const timerId = nextIntervalId;
+          nextIntervalId += 1;
+
+          intervalCallbacks.set(timerId, () => {
             if (typeof callback === "function") {
               const timerCallback = callback as () => void;
               timerCallback();
             }
-          };
-          return 1;
+          });
+
+          return timerId;
         }
       });
 
       Object.defineProperty(window, "clearInterval", {
         configurable: true,
-        value: () => {
-          intervalCallback = undefined;
+        value: (timerId: number) => {
+          intervalCallbacks.delete(timerId);
         }
       });
 
@@ -136,7 +141,9 @@ const bootHarness = async (page: Page, frames: (HandFrame | undefined)[]): Promi
         getDetectCount: () => detectCount,
         advanceCountdown: (ticks: number) => {
           for (let index = 0; index < ticks; index += 1) {
-            intervalCallback?.();
+            for (const callback of Array.from(intervalCallbacks.values())) {
+              callback();
+            }
           }
         },
         attachTelemetryObserver: () => {
@@ -180,29 +187,29 @@ const bootHarness = async (page: Page, frames: (HandFrame | undefined)[]): Promi
   });
 }
 
-const waitForFrameSequence = async (page: Page, frameCount: number): Promise<void> => {
-  await expect.poll(
-    async () =>
-      page.evaluate(() => window.__balloonShootTestHooks?.getDetectCount() ?? -1)
-  ).toBe(frameCount);
-};
-
-const readFrameSnapshots = async (page: Page): Promise<TelemetrySnapshot[]> => {
+const readFrameSnapshots = async (
+  page: Page,
+  expectedPhases: readonly string[]
+): Promise<TelemetrySnapshot[]> => {
   const timeline = await page.evaluate<TelemetrySnapshot[]>(() =>
     window.__balloonShootTestHooks?.getTelemetryTimeline() ?? []
   );
+  const meaningfulTimeline = timeline.filter((snapshot) => snapshot.phase !== "--");
 
-  return timeline.filter((snapshot) => snapshot.phase !== "--");
+  return meaningfulTimeline.slice(0, expectedPhases.length);
 };
 
-const stripTerminalTrackingLostSnapshot = (
-  snapshots: TelemetrySnapshot[]
-): TelemetrySnapshot[] => {
-  const terminalSnapshot = snapshots.at(-1);
+const waitForFrameSequence = async (
+  page: Page,
+  expectedPhases: readonly string[]
+): Promise<TelemetrySnapshot[]> => {
+  let snapshots: TelemetrySnapshot[] = [];
 
-  if (terminalSnapshot?.phase === "tracking_lost") {
-    return snapshots.slice(0, -1);
-  }
+  await expect.poll(async () => {
+    snapshots = await readFrameSnapshots(page, expectedPhases);
+
+    return snapshots.map((snapshot) => snapshot.phase);
+  }).toEqual(expectedPhases);
 
   return snapshots;
 };
@@ -217,19 +224,12 @@ test.describe("issue-30 acceptance", () => {
       withThumbTriggerPose(base, "pulled"),
       withThumbTriggerPose(base, "pulled")
     ];
+    const expectedPhases = ["idle", "ready", "armed", "armed", "fired", "tracking_lost"];
 
     await bootHarness(page, frames);
-    await waitForFrameSequence(page, frames.length);
-    const snapshots = await readFrameSnapshots(page);
+    const snapshots = await waitForFrameSequence(page, expectedPhases);
 
-    expect(snapshots.map((snapshot) => snapshot.phase)).toEqual([
-      "idle",
-      "ready",
-      "armed",
-      "armed",
-      "fired",
-      "tracking_lost"
-    ]);
+    expect(snapshots.map((snapshot) => snapshot.phase)).toEqual(expectedPhases);
     expect(snapshots).toContainEqual(
       expect.objectContaining({
         phase: "fired",
@@ -250,12 +250,7 @@ test.describe("issue-30 acceptance", () => {
       withThumbTriggerPose(base, "pulled"),
       withThumbTriggerPose(base, "pulled")
     ];
-
-    await bootHarness(page, frames);
-    await waitForFrameSequence(page, frames.length);
-    const snapshots = await readFrameSnapshots(page);
-
-    expect(snapshots.map((snapshot) => snapshot.phase)).toEqual([
+    const expectedPhases = [
       "idle",
       "ready",
       "armed",
@@ -264,7 +259,12 @@ test.describe("issue-30 acceptance", () => {
       "recovering",
       "recovering",
       "tracking_lost"
-    ]);
+    ];
+
+    await bootHarness(page, frames);
+    const snapshots = await waitForFrameSequence(page, expectedPhases);
+
+    expect(snapshots.map((snapshot) => snapshot.phase)).toEqual(expectedPhases);
     expect(snapshots.filter((snapshot) => snapshot.phase === "fired")).toHaveLength(1);
     expect(snapshots.at(-1)?.rejectReason).toBe("tracking_lost");
   });
@@ -279,11 +279,10 @@ test.describe("issue-30 acceptance", () => {
       withThumbTriggerPose(base, "open"),
       withThumbTriggerPose(base, "open")
     ];
+    const expectedPhases = ["idle", "ready", "armed", "armed", "armed", "armed"];
 
     await bootHarness(page, frames);
-    await waitForFrameSequence(page, frames.length);
-    const snapshots = await readFrameSnapshots(page);
-    const meaningfulSnapshots = stripTerminalTrackingLostSnapshot(snapshots);
+    const meaningfulSnapshots = await waitForFrameSequence(page, expectedPhases);
 
     expect(meaningfulSnapshots.map((snapshot) => snapshot.phase)).toEqual([
       "idle",
@@ -307,19 +306,12 @@ test.describe("issue-30 acceptance", () => {
       withThumbTriggerPose(base, "open"),
       withThumbTriggerPose(base, "open")
     ];
+    const expectedPhases = ["idle", "ready", "tracking_lost", "tracking_lost", "idle"];
 
     await bootHarness(page, frames);
-    await waitForFrameSequence(page, frames.length);
-    const snapshots = await readFrameSnapshots(page);
-    const meaningfulSnapshots = stripTerminalTrackingLostSnapshot(snapshots);
+    const meaningfulSnapshots = await waitForFrameSequence(page, expectedPhases);
 
-    expect(meaningfulSnapshots.map((snapshot) => snapshot.phase)).toEqual([
-      "idle",
-      "ready",
-      "tracking_lost",
-      "tracking_lost",
-      "idle"
-    ]);
+    expect(meaningfulSnapshots.map((snapshot) => snapshot.phase)).toEqual(expectedPhases);
     expect(meaningfulSnapshots.filter((snapshot) => snapshot.phase === "fired")).toHaveLength(0);
     expect(meaningfulSnapshots.at(2)?.rejectReason).toBe("tracking_lost");
     expect(meaningfulSnapshots.at(-1)?.rejectReason).toBe("waiting_for_stable_open");

--- a/tests/e2e/issue30.acceptance.spec.ts
+++ b/tests/e2e/issue30.acceptance.spec.ts
@@ -195,6 +195,18 @@ const readFrameSnapshots = async (page: Page): Promise<TelemetrySnapshot[]> => {
   return timeline.filter((snapshot) => snapshot.phase !== "--");
 };
 
+const stripTerminalTrackingLostSnapshot = (
+  snapshots: TelemetrySnapshot[]
+): TelemetrySnapshot[] => {
+  const terminalSnapshot = snapshots.at(-1);
+
+  if (terminalSnapshot?.phase === "tracking_lost") {
+    return snapshots.slice(0, -1);
+  }
+
+  return snapshots;
+};
+
 test.describe("issue-30 acceptance", () => {
   test("intentional pull emits exactly one shot", async ({ page }) => {
     const base = createBaseFrame();
@@ -271,8 +283,9 @@ test.describe("issue-30 acceptance", () => {
     await bootHarness(page, frames);
     await waitForFrameSequence(page, frames.length);
     const snapshots = await readFrameSnapshots(page);
+    const meaningfulSnapshots = stripTerminalTrackingLostSnapshot(snapshots);
 
-    expect(snapshots.map((snapshot) => snapshot.phase)).toEqual([
+    expect(meaningfulSnapshots.map((snapshot) => snapshot.phase)).toEqual([
       "idle",
       "ready",
       "armed",
@@ -280,8 +293,8 @@ test.describe("issue-30 acceptance", () => {
       "armed",
       "armed"
     ]);
-    expect(snapshots.filter((snapshot) => snapshot.phase === "fired")).toHaveLength(0);
-    expect(snapshots.at(-1)?.rejectReason).toBe("waiting_for_stable_pulled");
+    expect(meaningfulSnapshots.filter((snapshot) => snapshot.phase === "fired")).toHaveLength(0);
+    expect(meaningfulSnapshots.at(-1)?.rejectReason).toBe("waiting_for_stable_pulled");
   });
 
   test("tracking loss plus reacquisition does not ghost-fire", async ({ page }) => {
@@ -298,16 +311,17 @@ test.describe("issue-30 acceptance", () => {
     await bootHarness(page, frames);
     await waitForFrameSequence(page, frames.length);
     const snapshots = await readFrameSnapshots(page);
+    const meaningfulSnapshots = stripTerminalTrackingLostSnapshot(snapshots);
 
-    expect(snapshots.map((snapshot) => snapshot.phase)).toEqual([
+    expect(meaningfulSnapshots.map((snapshot) => snapshot.phase)).toEqual([
       "idle",
       "ready",
       "tracking_lost",
       "tracking_lost",
       "idle"
     ]);
-    expect(snapshots.filter((snapshot) => snapshot.phase === "fired")).toHaveLength(0);
-    expect(snapshots.at(2)?.rejectReason).toBe("tracking_lost");
-    expect(snapshots.at(-1)?.rejectReason).toBe("waiting_for_stable_open");
+    expect(meaningfulSnapshots.filter((snapshot) => snapshot.phase === "fired")).toHaveLength(0);
+    expect(meaningfulSnapshots.at(2)?.rejectReason).toBe("tracking_lost");
+    expect(meaningfulSnapshots.at(-1)?.rejectReason).toBe("waiting_for_stable_open");
   });
 });

--- a/tests/e2e/issue30.acceptance.spec.ts
+++ b/tests/e2e/issue30.acceptance.spec.ts
@@ -125,7 +125,7 @@ const bootHarness = async (page: Page, frames: (HandFrame | undefined)[]): Promi
           Promise.resolve({
             detect: () => {
               if (detectCount >= frames.length) {
-                return new Promise<HandFrame | undefined>(() => undefined);
+                return Promise.resolve(undefined);
               }
 
               const nextFrame = frames[detectCount];
@@ -215,7 +215,8 @@ test.describe("issue-30 acceptance", () => {
       "ready",
       "armed",
       "armed",
-      "fired"
+      "fired",
+      "tracking_lost"
     ]);
     expect(snapshots).toContainEqual(
       expect.objectContaining({
@@ -249,10 +250,11 @@ test.describe("issue-30 acceptance", () => {
       "armed",
       "fired",
       "recovering",
-      "recovering"
+      "recovering",
+      "tracking_lost"
     ]);
     expect(snapshots.filter((snapshot) => snapshot.phase === "fired")).toHaveLength(1);
-    expect(snapshots.at(-1)?.rejectReason).toBe("waiting_for_release");
+    expect(snapshots.at(-1)?.rejectReason).toBe("tracking_lost");
   });
 
   test("brief thumb jitter does not fire", async ({ page }) => {

--- a/tests/e2e/issue30.acceptance.spec.ts
+++ b/tests/e2e/issue30.acceptance.spec.ts
@@ -1,0 +1,311 @@
+import { expect, test, type Page } from "@playwright/test";
+import type { HandFrame } from "../../src/shared/types/hand";
+import {
+  createThumbTriggerFrame,
+  withThumbTriggerPose
+} from "../unit/features/input-mapping/thumbTriggerTestHelper";
+
+interface TelemetrySnapshot {
+  phase: string | null;
+  rejectReason: string | null;
+  trigger: string | null;
+  gunPose: string | null;
+  counters: string | null;
+}
+
+interface BrowserTestHooks {
+  createHandTracker: () => Promise<{
+    detect: (bitmap: ImageBitmap, frameAtMs: number) => Promise<HandFrame | undefined>;
+  }>;
+  getDetectCount: () => number;
+  advanceCountdown: (ticks: number) => void;
+  attachTelemetryObserver: () => void;
+  getTelemetryTimeline: () => TelemetrySnapshot[];
+}
+
+declare global {
+  interface Window {
+    __balloonShootTestHooks?: BrowserTestHooks;
+  }
+}
+
+const createBaseFrame = (): HandFrame => createThumbTriggerFrame("open");
+
+const createFrameSequence = (
+  frames: (HandFrame | undefined)[]
+): (HandFrame | null)[] => frames.map((frame) => frame ?? null);
+
+const bootHarness = async (page: Page, frames: (HandFrame | undefined)[]): Promise<void> => {
+  await page.addInitScript(
+    ({ scriptedFrames }) => {
+      const frames = scriptedFrames.slice();
+      let detectCount = 0;
+      let intervalCallback: (() => void) | undefined;
+      const telemetryTimeline: TelemetrySnapshot[] = [];
+      let telemetryObserver: MutationObserver | undefined;
+      let snapshotScheduled = false;
+
+      const snapshotCanvas = document.createElement("canvas");
+      snapshotCanvas.width = 2;
+      snapshotCanvas.height = 2;
+
+      const snapshotContext = snapshotCanvas.getContext("2d");
+
+      snapshotContext?.fillRect(0, 0, 2, 2);
+
+      const mediaStream = snapshotCanvas.captureStream(1);
+
+      Object.defineProperty(navigator, "mediaDevices", {
+        configurable: true,
+        value: {
+          getUserMedia: () => Promise.resolve(mediaStream)
+        }
+      });
+
+      Object.defineProperty(window, "ImageCapture", {
+        configurable: true,
+        value: class {
+          grabFrame(): Promise<ImageBitmap> {
+            return createImageBitmap(snapshotCanvas);
+          }
+        }
+      });
+
+      Object.defineProperty(window, "setInterval", {
+        configurable: true,
+        value: (callback: TimerHandler) => {
+          intervalCallback = () => {
+            if (typeof callback === "function") {
+              const timerCallback = callback as () => void;
+              timerCallback();
+            }
+          };
+          return 1;
+        }
+      });
+
+      Object.defineProperty(window, "clearInterval", {
+        configurable: true,
+        value: () => {
+          intervalCallback = undefined;
+        }
+      });
+
+      HTMLMediaElement.prototype.play = () => Promise.resolve();
+
+      const readTelemetrySnapshot = () => ({
+        phase: document.querySelector('[data-debug-output="phase"]')?.textContent ?? null,
+        rejectReason: document.querySelector('[data-debug-output="rejectReason"]')?.textContent ?? null,
+        trigger: document.querySelector('[data-debug-output="trigger"]')?.textContent ?? null,
+        gunPose: document.querySelector('[data-debug-output="gunPose"]')?.textContent ?? null,
+        counters: document.querySelector('[data-debug-output="counters"]')?.textContent ?? null
+      });
+
+      const pushTelemetrySnapshot = () => {
+        snapshotScheduled = false;
+        const snapshot = readTelemetrySnapshot();
+        const previous = telemetryTimeline.at(-1);
+
+        if (!previous || JSON.stringify(previous) !== JSON.stringify(snapshot)) {
+          telemetryTimeline.push(snapshot);
+        }
+      };
+
+      const scheduleTelemetrySnapshot = () => {
+        if (snapshotScheduled) {
+          return;
+        }
+
+        snapshotScheduled = true;
+        queueMicrotask(pushTelemetrySnapshot);
+      };
+
+      window.__balloonShootTestHooks = {
+        createHandTracker: () =>
+          Promise.resolve({
+            detect: () => {
+              if (detectCount >= frames.length) {
+                return new Promise<HandFrame | undefined>(() => undefined);
+              }
+
+              const nextFrame = frames[detectCount];
+              detectCount += 1;
+              return Promise.resolve(nextFrame ?? undefined);
+            }
+          }),
+        getDetectCount: () => detectCount,
+        advanceCountdown: (ticks: number) => {
+          for (let index = 0; index < ticks; index += 1) {
+            intervalCallback?.();
+          }
+        },
+        attachTelemetryObserver: () => {
+          if (telemetryObserver) {
+            return;
+          }
+
+          scheduleTelemetrySnapshot();
+          telemetryObserver = new MutationObserver(scheduleTelemetrySnapshot);
+          telemetryObserver.observe(document.body, {
+            childList: true,
+            subtree: true,
+            characterData: true
+          });
+        },
+        getTelemetryTimeline: () => telemetryTimeline.map((entry) => ({ ...entry }))
+      };
+    },
+    { scriptedFrames: createFrameSequence(frames) }
+  );
+
+  await page.goto("/");
+  await expect(page.locator('[data-debug-output="phase"]')).toHaveText("--");
+  await expect(page.locator('[data-debug-output="rejectReason"]')).toHaveText("--");
+  await expect(page.locator('[data-debug-output="trigger"]')).toHaveText("--");
+  await expect(page.locator('[data-debug-output="gunPose"]')).toHaveText("--");
+  await expect(page.locator('[data-debug-output="counters"]')).toHaveText(
+    "open=0 pull=0 track=0 pose=0"
+  );
+
+  await page.evaluate(() => {
+    window.__balloonShootTestHooks?.attachTelemetryObserver();
+  });
+
+  await page.getByRole("button", { name: "カメラを準備" }).click();
+  await expect(page.getByRole("button", { name: "スタート" })).toBeVisible();
+  await page.getByRole("button", { name: "スタート" }).click();
+
+  await page.evaluate(() => {
+    window.__balloonShootTestHooks?.advanceCountdown(3);
+  });
+}
+
+const waitForFrameSequence = async (page: Page, frameCount: number): Promise<void> => {
+  await expect.poll(
+    async () =>
+      page.evaluate(() => window.__balloonShootTestHooks?.getDetectCount() ?? -1)
+  ).toBe(frameCount);
+};
+
+const readFrameSnapshots = async (page: Page): Promise<TelemetrySnapshot[]> => {
+  const timeline = await page.evaluate<TelemetrySnapshot[]>(() =>
+    window.__balloonShootTestHooks?.getTelemetryTimeline() ?? []
+  );
+
+  return timeline.filter((snapshot) => snapshot.phase !== "--");
+};
+
+test.describe("issue-30 acceptance", () => {
+  test("intentional pull emits exactly one shot", async ({ page }) => {
+    const base = createBaseFrame();
+    const frames = [
+      withThumbTriggerPose(base, "open"),
+      withThumbTriggerPose(base, "open"),
+      withThumbTriggerPose(base, "open"),
+      withThumbTriggerPose(base, "pulled"),
+      withThumbTriggerPose(base, "pulled")
+    ];
+
+    await bootHarness(page, frames);
+    await waitForFrameSequence(page, frames.length);
+    const snapshots = await readFrameSnapshots(page);
+
+    expect(snapshots.map((snapshot) => snapshot.phase)).toEqual([
+      "idle",
+      "ready",
+      "armed",
+      "armed",
+      "fired"
+    ]);
+    expect(snapshots).toContainEqual(
+      expect.objectContaining({
+        phase: "fired",
+        rejectReason: "waiting_for_release"
+      })
+    );
+    expect(snapshots.filter((snapshot) => snapshot.phase === "fired")).toHaveLength(1);
+  });
+
+  test("held pull does not auto-repeat", async ({ page }) => {
+    const base = createBaseFrame();
+    const frames = [
+      withThumbTriggerPose(base, "open"),
+      withThumbTriggerPose(base, "open"),
+      withThumbTriggerPose(base, "open"),
+      withThumbTriggerPose(base, "pulled"),
+      withThumbTriggerPose(base, "pulled"),
+      withThumbTriggerPose(base, "pulled"),
+      withThumbTriggerPose(base, "pulled")
+    ];
+
+    await bootHarness(page, frames);
+    await waitForFrameSequence(page, frames.length);
+    const snapshots = await readFrameSnapshots(page);
+
+    expect(snapshots.map((snapshot) => snapshot.phase)).toEqual([
+      "idle",
+      "ready",
+      "armed",
+      "armed",
+      "fired",
+      "recovering",
+      "recovering"
+    ]);
+    expect(snapshots.filter((snapshot) => snapshot.phase === "fired")).toHaveLength(1);
+    expect(snapshots.at(-1)?.rejectReason).toBe("waiting_for_release");
+  });
+
+  test("brief thumb jitter does not fire", async ({ page }) => {
+    const base = createBaseFrame();
+    const frames = [
+      withThumbTriggerPose(base, "open"),
+      withThumbTriggerPose(base, "open"),
+      withThumbTriggerPose(base, "open"),
+      withThumbTriggerPose(base, "pulled"),
+      withThumbTriggerPose(base, "open"),
+      withThumbTriggerPose(base, "open")
+    ];
+
+    await bootHarness(page, frames);
+    await waitForFrameSequence(page, frames.length);
+    const snapshots = await readFrameSnapshots(page);
+
+    expect(snapshots.map((snapshot) => snapshot.phase)).toEqual([
+      "idle",
+      "ready",
+      "armed",
+      "armed",
+      "armed",
+      "armed"
+    ]);
+    expect(snapshots.filter((snapshot) => snapshot.phase === "fired")).toHaveLength(0);
+    expect(snapshots.at(-1)?.rejectReason).toBe("waiting_for_stable_pulled");
+  });
+
+  test("tracking loss plus reacquisition does not ghost-fire", async ({ page }) => {
+    const base = createBaseFrame();
+    const frames = [
+      withThumbTriggerPose(base, "open"),
+      withThumbTriggerPose(base, "open"),
+      undefined,
+      undefined,
+      withThumbTriggerPose(base, "open"),
+      withThumbTriggerPose(base, "open")
+    ];
+
+    await bootHarness(page, frames);
+    await waitForFrameSequence(page, frames.length);
+    const snapshots = await readFrameSnapshots(page);
+
+    expect(snapshots.map((snapshot) => snapshot.phase)).toEqual([
+      "idle",
+      "ready",
+      "tracking_lost",
+      "tracking_lost",
+      "idle"
+    ]);
+    expect(snapshots.filter((snapshot) => snapshot.phase === "fired")).toHaveLength(0);
+    expect(snapshots.at(2)?.rejectReason).toBe("tracking_lost");
+    expect(snapshots.at(-1)?.rejectReason).toBe("waiting_for_stable_open");
+  });
+});

--- a/tests/unit/app/bootstrap/startApp.test.ts
+++ b/tests/unit/app/bootstrap/startApp.test.ts
@@ -199,6 +199,7 @@ describe("startApp", () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
+    telemetryCalls.length = 0;
 
     let nextAnimationFrameId = 1;
     animationFrameCallbacks = [];

--- a/tests/unit/app/bootstrap/startApp.test.ts
+++ b/tests/unit/app/bootstrap/startApp.test.ts
@@ -523,7 +523,7 @@ describe("startApp", () => {
       }
     );
 
-    const crosshairTransitions = drawCalls.reduce<Array<"defined" | "undefined">>(
+    const crosshairTransitions = drawCalls.reduce<("defined" | "undefined")[]>(
       (transitions, state) => {
         const nextTransition = state.crosshair === undefined ? "undefined" : "defined";
 

--- a/tests/unit/app/bootstrap/startApp.test.ts
+++ b/tests/unit/app/bootstrap/startApp.test.ts
@@ -505,18 +505,42 @@ describe("startApp", () => {
     await flushPromises();
 
     overlayRoot.click("start");
-    await tickCountdown(3);
+    await tickCountdown(2);
 
-    for (let index = 0; index < 10; index += 1) {
+    const drawCallsBeforePlaying = drawGameFrameMock.mock.calls.length;
+
+    await tickCountdown(1);
+
+    expect(overlayRoot.innerHTML).toContain('data-screen="playing"');
+
+    for (let index = 0; index < 20; index += 1) {
       await runNextAnimationFrame();
     }
 
-    const drawCalls = drawGameFrameMock.mock.calls.map(([, state]) => state as {
-      crosshair?: { x: number; y: number };
-    });
+    const drawCalls = drawGameFrameMock.mock.calls.slice(drawCallsBeforePlaying).map(([, state]) =>
+      state as {
+        crosshair?: { x: number; y: number };
+      }
+    );
 
-    expect(drawCalls.some((state) => state.crosshair === undefined)).toBe(true);
-    expect(drawCalls.some((state) => state.crosshair !== undefined)).toBe(true);
+    const crosshairTransitions = drawCalls.reduce<Array<"defined" | "undefined">>(
+      (transitions, state) => {
+        const nextTransition = state.crosshair === undefined ? "undefined" : "defined";
+
+        if (transitions.at(-1) !== nextTransition) {
+          transitions.push(nextTransition);
+        }
+
+        return transitions;
+      },
+      []
+    );
+
+    expect(crosshairTransitions.slice(0, 3)).toEqual([
+      "defined",
+      "undefined",
+      "defined"
+    ]);
   });
 
   it("keeps the app in ready state when tracker prewarm fails (non-fatal)", async () => {

--- a/tests/unit/app/bootstrap/startApp.test.ts
+++ b/tests/unit/app/bootstrap/startApp.test.ts
@@ -192,6 +192,26 @@ const createTrackingLossHandFrames = () => [
   withThumbTriggerPose(createThumbTriggerFrame("open"), "open")
 ];
 
+const mockAudioAndCameraControllers = (
+  requestStream: () => Promise<unknown>,
+  stop = vi.fn()
+): typeof stop => {
+  createAudioControllerMock.mockReturnValue({
+    startBgm: vi.fn(() => Promise.resolve()),
+    stopBgm: vi.fn(),
+    playShot: vi.fn(() => Promise.resolve()),
+    playHit: vi.fn(() => Promise.resolve()),
+    playTimeout: vi.fn(() => Promise.resolve()),
+    playResult: vi.fn(() => Promise.resolve())
+  });
+  createCameraControllerMock.mockReturnValue({
+    requestStream: vi.fn(requestStream),
+    stop
+  });
+
+  return stop;
+};
+
 describe("startApp", () => {
   let intervalCallback: (() => void) | undefined;
   let animationFrameCallbacks: (FrameRequestCallback | undefined)[];
@@ -271,18 +291,9 @@ describe("startApp", () => {
   };
 
   it("seeds the debug panel from shared input config", async () => {
-    createAudioControllerMock.mockReturnValue({
-      startBgm: vi.fn(() => Promise.resolve()),
-      stopBgm: vi.fn(),
-      playShot: vi.fn(() => Promise.resolve()),
-      playHit: vi.fn(() => Promise.resolve()),
-      playTimeout: vi.fn(() => Promise.resolve()),
-      playResult: vi.fn(() => Promise.resolve())
-    });
-    createCameraControllerMock.mockReturnValue({
-      requestStream: vi.fn(() => Promise.resolve({ getTracks: () => [], getVideoTracks: () => [] })),
-      stop: vi.fn()
-    });
+    mockAudioAndCameraControllers(() =>
+      Promise.resolve({ getTracks: () => [], getVideoTracks: () => [] })
+    );
     createMediaPipeHandTrackerMock.mockResolvedValue({ detect: vi.fn() });
 
     const { startApp } = await import("../../../../src/app/bootstrap/startApp");
@@ -297,18 +308,7 @@ describe("startApp", () => {
 
   it("clears the prewarmed tracker promise when camera startup fails so the user can retry", async () => {
     const cameraStop = vi.fn();
-    createAudioControllerMock.mockReturnValue({
-      startBgm: vi.fn(() => Promise.resolve()),
-      stopBgm: vi.fn(),
-      playShot: vi.fn(() => Promise.resolve()),
-      playHit: vi.fn(() => Promise.resolve()),
-      playTimeout: vi.fn(() => Promise.resolve()),
-      playResult: vi.fn(() => Promise.resolve())
-    });
-    createCameraControllerMock.mockReturnValue({
-      requestStream: vi.fn(() => Promise.reject(new Error("camera denied"))),
-      stop: cameraStop
-    });
+    mockAudioAndCameraControllers(() => Promise.reject(new Error("camera denied")), cameraStop);
     createMediaPipeHandTrackerMock.mockResolvedValue({
       detect: vi.fn()
     });
@@ -343,23 +343,14 @@ describe("startApp", () => {
       detect: vi.fn(() => Promise.resolve(scriptedFrames.shift()))
     };
 
-    createAudioControllerMock.mockReturnValue({
-      startBgm: vi.fn(() => Promise.resolve()),
-      stopBgm: vi.fn(),
-      playShot: vi.fn(() => Promise.resolve()),
-      playHit: vi.fn(() => Promise.resolve()),
-      playTimeout: vi.fn(() => Promise.resolve()),
-      playResult: vi.fn(() => Promise.resolve())
-    });
-    createCameraControllerMock.mockReturnValue({
-      requestStream: vi.fn(() =>
-        Promise.resolve({
+    mockAudioAndCameraControllers(() =>
+      Promise.resolve(
+        {
           getTracks: () => [],
           getVideoTracks: () => [{ kind: "video" } as MediaStreamTrack]
-        } as unknown as MediaStream)
-      ),
-      stop: vi.fn()
-    });
+        } as unknown as MediaStream
+      )
+    );
 
     createHandTracker.mockResolvedValue(scriptedTracker);
 
@@ -404,23 +395,14 @@ describe("startApp", () => {
       detect: vi.fn(() => Promise.resolve(scriptedFrames.shift()))
     };
 
-    createAudioControllerMock.mockReturnValue({
-      startBgm: vi.fn(() => Promise.resolve()),
-      stopBgm: vi.fn(),
-      playShot: vi.fn(() => Promise.resolve()),
-      playHit: vi.fn(() => Promise.resolve()),
-      playTimeout: vi.fn(() => Promise.resolve()),
-      playResult: vi.fn(() => Promise.resolve())
-    });
-    createCameraControllerMock.mockReturnValue({
-      requestStream: vi.fn(() =>
-        Promise.resolve({
+    mockAudioAndCameraControllers(() =>
+      Promise.resolve(
+        {
           getTracks: () => [],
           getVideoTracks: () => [{ kind: "video" } as MediaStreamTrack]
-        } as unknown as MediaStream)
-      ),
-      stop: vi.fn()
-    });
+        } as unknown as MediaStream
+      )
+    );
 
     createHandTracker.mockResolvedValue(scriptedTracker);
 
@@ -551,18 +533,7 @@ describe("startApp", () => {
       getVideoTracks: () => []
     } as unknown as MediaStream;
 
-    createAudioControllerMock.mockReturnValue({
-      startBgm: vi.fn(() => Promise.resolve()),
-      stopBgm: vi.fn(),
-      playShot: vi.fn(() => Promise.resolve()),
-      playHit: vi.fn(() => Promise.resolve()),
-      playTimeout: vi.fn(() => Promise.resolve()),
-      playResult: vi.fn(() => Promise.resolve())
-    });
-    createCameraControllerMock.mockReturnValue({
-      requestStream: vi.fn(() => Promise.resolve(stream)),
-      stop: cameraStop
-    });
+    mockAudioAndCameraControllers(() => Promise.resolve(stream), cameraStop);
     createMediaPipeHandTrackerMock.mockImplementationOnce(() =>
       Promise.reject(trackerStartupError)
     );

--- a/tests/unit/app/bootstrap/startApp.test.ts
+++ b/tests/unit/app/bootstrap/startApp.test.ts
@@ -1,4 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { DebugTelemetry } from "../../../../src/features/debug/createDebugPanel";
+import type { HandFrame } from "../../../../src/shared/types/hand";
+import { createThumbTriggerFrame, withThumbTriggerPose } from "../../features/input-mapping/thumbTriggerTestHelper";
+
+interface ScriptedHandTracker {
+  detect: (bitmap: ImageBitmap, frameAtMs: number) => Promise<HandFrame | undefined>;
+}
 
 const {
   createAudioControllerMock,
@@ -9,6 +16,7 @@ const {
   drawGameFrameMock,
   createDebugPanelMock,
   debugPanelInstance,
+  telemetryCalls,
   inputConfig
 } = vi.hoisted(() => {
   const inputConfig = {
@@ -16,10 +24,18 @@ const {
     triggerPullThreshold: 0.45,
     triggerReleaseThreshold: 0.25
   };
+  const telemetryCalls: DebugTelemetry[] = [];
   const debugPanelInstance = {
     values: { ...inputConfig },
     render: vi.fn(() => `<aside class="debug-panel"></aside>`),
-    bind: vi.fn()
+    bind: vi.fn(() => undefined),
+    setTelemetry: vi.fn((telemetry: DebugTelemetry | undefined) => {
+      if (telemetry) {
+        telemetryCalls.push(telemetry);
+      }
+
+      return undefined;
+    })
   };
   return {
     createAudioControllerMock: vi.fn(),
@@ -37,6 +53,7 @@ const {
     drawGameFrameMock: vi.fn(),
     createDebugPanelMock: vi.fn(() => debugPanelInstance),
     debugPanelInstance,
+    telemetryCalls,
     inputConfig
   };
 });
@@ -159,13 +176,33 @@ const flushPromises = async (): Promise<void> => {
   await Promise.resolve();
 };
 
+const createScriptedHandFrames = () => [
+  withThumbTriggerPose(createThumbTriggerFrame("open"), "open"),
+  withThumbTriggerPose(createThumbTriggerFrame("open"), "open"),
+  withThumbTriggerPose(createThumbTriggerFrame("pulled"), "pulled"),
+  withThumbTriggerPose(createThumbTriggerFrame("pulled"), "pulled")
+];
+
+const createTrackingLossHandFrames = () => [
+  withThumbTriggerPose(createThumbTriggerFrame("open"), "open"),
+  withThumbTriggerPose(createThumbTriggerFrame("open"), "open"),
+  undefined,
+  undefined,
+  withThumbTriggerPose(createThumbTriggerFrame("open"), "open"),
+  withThumbTriggerPose(createThumbTriggerFrame("open"), "open")
+];
+
 describe("startApp", () => {
+  let intervalCallback: (() => void) | undefined;
+  let animationFrameCallbacks: (FrameRequestCallback | undefined)[];
+
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
 
     let nextAnimationFrameId = 1;
-    const animationFrames = new Map<number, FrameRequestCallback>();
+    animationFrameCallbacks = [];
+    intervalCallback = undefined;
 
     vi.stubGlobal("Element", FakeElement);
 
@@ -173,16 +210,19 @@ describe("startApp", () => {
       innerWidth: 1280,
       innerHeight: 720,
       addEventListener: vi.fn(),
-      setInterval: vi.fn(() => 1),
+      setInterval: vi.fn((callback: () => void) => {
+        intervalCallback = callback;
+        return 1;
+      }),
       clearInterval: vi.fn(),
       requestAnimationFrame: vi.fn((callback: FrameRequestCallback) => {
         const id = nextAnimationFrameId;
         nextAnimationFrameId += 1;
-        animationFrames.set(id, callback);
+        animationFrameCallbacks[id - 1] = callback;
         return id;
       }),
       cancelAnimationFrame: vi.fn((id: number) => {
-        animationFrames.delete(id);
+        animationFrameCallbacks[id - 1] = undefined;
       }),
       ImageCapture: class {
         grabFrame(): Promise<ImageBitmap> {
@@ -204,6 +244,30 @@ describe("startApp", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
   });
+
+  const runNextAnimationFrame = async (timestamp = 0): Promise<void> => {
+    const callbackIndex = animationFrameCallbacks.findIndex((callback) => callback !== undefined);
+
+    if (callbackIndex === -1) {
+      throw new Error("Expected an animation frame callback to be queued");
+    }
+
+    const callback = animationFrameCallbacks[callbackIndex];
+    if (!callback) {
+      throw new Error("Expected an animation frame callback to be queued");
+    }
+
+    animationFrameCallbacks[callbackIndex] = undefined;
+    callback(timestamp);
+    await flushPromises();
+  };
+
+  const tickCountdown = async (ticks: number): Promise<void> => {
+    for (let index = 0; index < ticks; index += 1) {
+      intervalCallback?.();
+      await flushPromises();
+    }
+  };
 
   it("seeds the debug panel from shared input config", async () => {
     createAudioControllerMock.mockReturnValue({
@@ -265,6 +329,193 @@ describe("startApp", () => {
     await flushPromises();
 
     expect(createMediaPipeHandTrackerMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("accepts a debug-only synthetic hand tracker factory for scripted frame sequences", async () => {
+    const createHandTracker = vi.fn(() =>
+      Promise.resolve<ScriptedHandTracker>({
+        detect: vi.fn(() => Promise.resolve(undefined as HandFrame | undefined))
+      })
+    );
+    const scriptedFrames = createScriptedHandFrames();
+    const scriptedTracker: ScriptedHandTracker = {
+      detect: vi.fn(() => Promise.resolve(scriptedFrames.shift()))
+    };
+
+    createAudioControllerMock.mockReturnValue({
+      startBgm: vi.fn(() => Promise.resolve()),
+      stopBgm: vi.fn(),
+      playShot: vi.fn(() => Promise.resolve()),
+      playHit: vi.fn(() => Promise.resolve()),
+      playTimeout: vi.fn(() => Promise.resolve()),
+      playResult: vi.fn(() => Promise.resolve())
+    });
+    createCameraControllerMock.mockReturnValue({
+      requestStream: vi.fn(() =>
+        Promise.resolve({
+          getTracks: () => [],
+          getVideoTracks: () => [{ kind: "video" } as MediaStreamTrack]
+        } as unknown as MediaStream)
+      ),
+      stop: vi.fn()
+    });
+
+    createHandTracker.mockResolvedValue(scriptedTracker);
+
+    const { startApp } = await import("../../../../src/app/bootstrap/startApp");
+    const { root, overlayRoot } = createFakeRoot();
+
+    (startApp as unknown as (
+      root: HTMLDivElement,
+      debugValues: unknown,
+      debugHooks: { createHandTracker: typeof createHandTracker }
+    ) => void)(root as unknown as HTMLDivElement, undefined, { createHandTracker });
+
+    overlayRoot.click("camera");
+    await flushPromises();
+    expect(createMediaPipeHandTrackerMock).not.toHaveBeenCalled();
+    expect(createHandTracker).toHaveBeenCalledTimes(1);
+
+    overlayRoot.click("start");
+    await tickCountdown(3);
+
+    await runNextAnimationFrame();
+    await runNextAnimationFrame();
+    await runNextAnimationFrame();
+    await runNextAnimationFrame();
+    await runNextAnimationFrame();
+    await runNextAnimationFrame();
+    await runNextAnimationFrame();
+    await runNextAnimationFrame();
+
+    expect(scriptedTracker.detect).toHaveBeenCalledTimes(4);
+    expect(scriptedFrames).toHaveLength(0);
+  });
+
+  it("bridges mapper runtime telemetry into the debug panel without affecting gameplay flow", async () => {
+    const createHandTracker = vi.fn(() =>
+      Promise.resolve<ScriptedHandTracker>({
+        detect: vi.fn(() => Promise.resolve(undefined as HandFrame | undefined))
+      })
+    );
+    const scriptedFrames = createScriptedHandFrames();
+    const scriptedTracker: ScriptedHandTracker = {
+      detect: vi.fn(() => Promise.resolve(scriptedFrames.shift()))
+    };
+
+    createAudioControllerMock.mockReturnValue({
+      startBgm: vi.fn(() => Promise.resolve()),
+      stopBgm: vi.fn(),
+      playShot: vi.fn(() => Promise.resolve()),
+      playHit: vi.fn(() => Promise.resolve()),
+      playTimeout: vi.fn(() => Promise.resolve()),
+      playResult: vi.fn(() => Promise.resolve())
+    });
+    createCameraControllerMock.mockReturnValue({
+      requestStream: vi.fn(() =>
+        Promise.resolve({
+          getTracks: () => [],
+          getVideoTracks: () => [{ kind: "video" } as MediaStreamTrack]
+        } as unknown as MediaStream)
+      ),
+      stop: vi.fn()
+    });
+
+    createHandTracker.mockResolvedValue(scriptedTracker);
+
+    const { startApp } = await import("../../../../src/app/bootstrap/startApp");
+    const { root, overlayRoot } = createFakeRoot();
+
+    (startApp as unknown as (
+      root: HTMLDivElement,
+      debugValues: unknown,
+      debugHooks: { createHandTracker: typeof createHandTracker }
+    ) => void)(root as unknown as HTMLDivElement, undefined, { createHandTracker });
+
+    overlayRoot.click("camera");
+    await flushPromises();
+    overlayRoot.click("start");
+    await tickCountdown(3);
+
+    for (let index = 0; index < 7; index += 1) {
+      await runNextAnimationFrame();
+    }
+
+    const lastTelemetry = telemetryCalls.at(-1);
+
+    expect(debugPanelInstance.setTelemetry).toHaveBeenCalled();
+    expect(lastTelemetry).toBeDefined();
+    if (!lastTelemetry) {
+      throw new Error("Expected telemetry to be present");
+    }
+
+    expect(typeof lastTelemetry.phase).toBe("string");
+    expect(typeof lastTelemetry.rejectReason).toBe("string");
+    expect(lastTelemetry.triggerConfidence).toBeGreaterThanOrEqual(0);
+    expect(lastTelemetry.gunPoseConfidence).toBeGreaterThanOrEqual(0);
+    expect(lastTelemetry.openFrames).toBeGreaterThanOrEqual(0);
+    expect(lastTelemetry.pulledFrames).toBeGreaterThanOrEqual(0);
+    expect(lastTelemetry.trackingPresentFrames).toBeGreaterThanOrEqual(0);
+    expect(lastTelemetry.nonGunPoseFrames).toBeGreaterThanOrEqual(0);
+    expect(telemetryCalls.some((telemetry) => telemetry.phase === "armed")).toBe(true);
+  });
+
+  it("hides the crosshair while tracking is lost and restores it after reacquisition", async () => {
+    const createHandTracker = vi.fn(() =>
+      Promise.resolve<ScriptedHandTracker>({
+        detect: vi.fn(() => Promise.resolve(undefined as HandFrame | undefined))
+      })
+    );
+    const scriptedFrames = createTrackingLossHandFrames();
+    const scriptedTracker: ScriptedHandTracker = {
+      detect: vi.fn(() => Promise.resolve(scriptedFrames.shift()))
+    };
+
+    createAudioControllerMock.mockReturnValue({
+      startBgm: vi.fn(() => Promise.resolve()),
+      stopBgm: vi.fn(),
+      playShot: vi.fn(() => Promise.resolve()),
+      playHit: vi.fn(() => Promise.resolve()),
+      playTimeout: vi.fn(() => Promise.resolve()),
+      playResult: vi.fn(() => Promise.resolve())
+    });
+    createCameraControllerMock.mockReturnValue({
+      requestStream: vi.fn(() =>
+        Promise.resolve({
+          getTracks: () => [],
+          getVideoTracks: () => [{ kind: "video" } as MediaStreamTrack]
+        } as unknown as MediaStream)
+      ),
+      stop: vi.fn()
+    });
+
+    createHandTracker.mockResolvedValue(scriptedTracker);
+
+    const { startApp } = await import("../../../../src/app/bootstrap/startApp");
+    const { root, overlayRoot } = createFakeRoot();
+
+    (startApp as unknown as (
+      root: HTMLDivElement,
+      debugValues: unknown,
+      debugHooks: { createHandTracker: typeof createHandTracker }
+    ) => void)(root as unknown as HTMLDivElement, undefined, { createHandTracker });
+
+    overlayRoot.click("camera");
+    await flushPromises();
+
+    overlayRoot.click("start");
+    await tickCountdown(3);
+
+    for (let index = 0; index < 10; index += 1) {
+      await runNextAnimationFrame();
+    }
+
+    const drawCalls = drawGameFrameMock.mock.calls.map(([, state]) => state as {
+      crosshair?: { x: number; y: number };
+    });
+
+    expect(drawCalls.some((state) => state.crosshair === undefined)).toBe(true);
+    expect(drawCalls.some((state) => state.crosshair !== undefined)).toBe(true);
   });
 
   it("keeps the app in ready state when tracker prewarm fails (non-fatal)", async () => {

--- a/tests/unit/features/debug/createDebugPanel.test.ts
+++ b/tests/unit/features/debug/createDebugPanel.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import {
   createDebugPanel,
   type DebugInputElement,
+  type DebugOutputElement,
+  type DebugTelemetry,
   type DebugValues
 } from "../../../../src/features/debug/createDebugPanel";
 
@@ -14,6 +16,8 @@ const sampleInitial: DebugValues = {
 interface FakeInput extends DebugInputElement {
   fireInput: () => void;
 }
+
+type FakeOutput = DebugOutputElement;
 
 const createFakeInput = (key: string, initialValue: string): FakeInput => {
   let listener: (() => void) | undefined;
@@ -35,6 +39,22 @@ const createFakeInput = (key: string, initialValue: string): FakeInput => {
     }
   };
   return input;
+};
+
+const createFakeOutput = (key: string): FakeOutput => ({
+  dataset: { debugOutput: key },
+  textContent: ""
+});
+
+const sampleTelemetry: DebugTelemetry = {
+  phase: "armed",
+  rejectReason: "waiting_for_stable_pulled",
+  triggerConfidence: 0.67,
+  gunPoseConfidence: 0.91,
+  openFrames: 0,
+  pulledFrames: 1,
+  trackingPresentFrames: 4,
+  nonGunPoseFrames: 0
 };
 
 describe("createDebugPanel", () => {
@@ -61,6 +81,29 @@ describe("createDebugPanel", () => {
     expect(html).toContain('max="0.4"');
     expect(html).toContain('min="0.02"');
     expect(html).toContain('max="0.25"');
+    expect(html).toContain('data-debug-output="phase"');
+    expect(html).toContain('data-debug-output="rejectReason"');
+    expect(html).toContain('data-debug-output="trigger"');
+    expect(html).toContain('data-debug-output="gunPose"');
+    expect(html).toContain('data-debug-output="counters"');
+  });
+
+  it("renders compact runtime telemetry into bound debug outputs", () => {
+    const panel = createDebugPanel(sampleInitial);
+    const phase = createFakeOutput("phase");
+    const rejectReason = createFakeOutput("rejectReason");
+    const trigger = createFakeOutput("trigger");
+    const gunPose = createFakeOutput("gunPose");
+    const counters = createFakeOutput("counters");
+
+    panel.bind([], [phase, rejectReason, trigger, gunPose, counters]);
+    panel.setTelemetry(sampleTelemetry);
+
+    expect(phase.textContent).toBe("armed");
+    expect(rejectReason.textContent).toBe("waiting_for_stable_pulled");
+    expect(trigger.textContent).toBe("0.67");
+    expect(gunPose.textContent).toBe("0.91");
+    expect(counters.textContent).toBe("open=0 pull=1 track=4 pose=0");
   });
 
   it("updates values in place when bound inputs fire", () => {

--- a/tests/unit/features/input-mapping/mapHandToGameInput.test.ts
+++ b/tests/unit/features/input-mapping/mapHandToGameInput.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { smoothCrosshair } from "../../../../src/features/input-mapping/createCrosshairSmoother";
-import { evaluateGunPose } from "../../../../src/features/input-mapping/evaluateGunPose";
+import { evaluateGunPose, measureGunPose } from "../../../../src/features/input-mapping/evaluateGunPose";
 import {
+  buildHandEvidence,
   mapHandToGameInput,
   type GameInputFrame,
   type InputTuning
@@ -10,11 +11,20 @@ import { gameConfig } from "../../../../src/shared/config/gameConfig";
 import type { HandFrame } from "../../../../src/shared/types/hand";
 import {
   createThumbTriggerFrame,
+  type ThumbTriggerPose,
   withThumbTriggerPose
 } from "./thumbTriggerTestHelper";
 
 const frame: HandFrame = createThumbTriggerFrame("open");
 const canvasSize = { width: 1280, height: 720 };
+
+const expectDefined = <T>(value: T | null | undefined, message: string): T => {
+  if (value === undefined || value === null) {
+    throw new Error(message);
+  }
+
+  return value;
+};
 
 const runInputSequence = (
   frames: HandFrame[],
@@ -62,7 +72,87 @@ const withGunPose = (inputFrame: HandFrame, active: boolean): HandFrame =>
         }
       };
 
+const withGunPoseActive = withGunPose;
+
+const withLowConfidenceGunPose = (inputFrame: HandFrame): HandFrame => ({
+  ...inputFrame,
+  landmarks: {
+    ...inputFrame.landmarks,
+    indexTip: { ...inputFrame.landmarks.indexTip, y: inputFrame.landmarks.indexMcp.y - 0.01 },
+    middleTip: { ...inputFrame.landmarks.middleTip, y: inputFrame.landmarks.indexMcp.y + 0.04 },
+    ringTip: { ...inputFrame.landmarks.ringTip, y: inputFrame.landmarks.indexMcp.y + 0.04 },
+    pinkyTip: { ...inputFrame.landmarks.pinkyTip, y: inputFrame.landmarks.indexMcp.y + 0.04 }
+  }
+});
+
+interface Issue30FrameStep {
+  pose: ThumbTriggerPose;
+  gunPoseActive?: boolean;
+}
+
+const createIssue30Frame = (
+  pose: ThumbTriggerPose,
+  gunPoseActive = true
+): HandFrame => withGunPoseActive(withThumbTriggerPose(frame, pose), gunPoseActive);
+
+const runIssue30Sequence = (
+  steps: Issue30FrameStep[],
+  initialRuntime: GameInputFrame["runtime"] = createArmedRuntime()
+): GameInputFrame[] =>
+  runInputSequence(
+    steps.map(({ pose, gunPoseActive = true }) => createIssue30Frame(pose, gunPoseActive)),
+    initialRuntime
+  );
+
 describe("mapHandToGameInput", () => {
+  it("builds hand evidence without conflating tracking presence with trigger state", () => {
+    const evidence = buildHandEvidence(frame, canvasSize, undefined, 1234, gameConfig.input);
+
+    expect(evidence.trackingPresent).toBe(true);
+    expect(evidence.frameAtMs).toBe(1234);
+    const trigger = expectDefined(evidence.trigger, "Expected trigger evidence");
+    const gunPose = expectDefined(evidence.gunPose, "Expected gun pose evidence");
+    const smoothedCrosshairCandidate = expectDefined(
+      evidence.smoothedCrosshairCandidate,
+      "Expected smoothed crosshair"
+    );
+
+    expect(trigger.rawState).toBe("open");
+    expect(trigger.confidence).toBeGreaterThanOrEqual(0);
+    expect(trigger.confidence).toBeLessThanOrEqual(1);
+    expect(trigger.details.projection).toEqual(expect.any(Number));
+    expect(gunPose.detected).toBe(true);
+    expect(gunPose.confidence).toBeGreaterThanOrEqual(0);
+    expect(gunPose.confidence).toBeLessThanOrEqual(1);
+    expect(gunPose.details.indexExtended).toBe(true);
+    expect(smoothedCrosshairCandidate.x).toBeTypeOf("number");
+    expect(smoothedCrosshairCandidate.y).toBeTypeOf("number");
+  });
+
+  it("represents missing tracking explicitly instead of inventing trigger state", () => {
+    const evidence = buildHandEvidence(undefined, canvasSize, undefined, 5678, gameConfig.input);
+
+    expect(evidence.trackingPresent).toBe(false);
+    expect(evidence.frameAtMs).toBe(5678);
+    expect(evidence.smoothedCrosshairCandidate).toBeNull();
+    expect(evidence.trigger).toBeNull();
+    expect(evidence.gunPose).toBeNull();
+  });
+
+  it("turns missing tracking into tracking_lost and clears the crosshair", () => {
+    const result = mapHandToGameInput(
+      undefined as unknown as HandFrame,
+      canvasSize,
+      createArmedRuntime()
+    );
+
+    expect(result.runtime.phase).toBe("tracking_lost");
+    expect(result.runtime.rejectReason).toBe("tracking_lost");
+    expect(result.shotFired).toBe(false);
+    expect(result.crosshair).toBeUndefined();
+    expect(result.runtime.crosshair).toBeUndefined();
+  });
+
   it("detects a gun pose using hand-size-normalized curl distance", () => {
     expect(
       evaluateGunPose({
@@ -80,6 +170,54 @@ describe("mapHandToGameInput", () => {
         }
       })
     ).toBe(true);
+  });
+
+  it("pose-drop tolerance: one-frame weak gun pose should not emit shot", () => {
+    const weakPoseFrame = {
+      ...frame,
+      landmarks: {
+        ...frame.landmarks,
+        indexTip: { ...frame.landmarks.indexTip, y: frame.landmarks.indexMcp.y - 0.01 },
+        middleTip: { ...frame.landmarks.middleTip, y: frame.landmarks.indexMcp.y + 0.04 },
+        ringTip: { ...frame.landmarks.ringTip, y: frame.landmarks.indexMcp.y + 0.04 },
+        pinkyTip: { ...frame.landmarks.pinkyTip, y: frame.landmarks.indexMcp.y + 0.04 }
+      }
+    } as const;
+
+    const results = runInputSequence(
+      [
+        withThumbTriggerPose(frame, "open"),
+        withThumbTriggerPose(weakPoseFrame, "pulled"),
+        withThumbTriggerPose(weakPoseFrame, "pulled")
+      ],
+      createArmedRuntime()
+    );
+
+    expect(results.some((result) => result.shotFired)).toBe(false);
+    expect(evaluateGunPose(weakPoseFrame)).toBe(false);
+    expect(results[1]?.gunPoseActive).toBe(true);
+    expect(results[2]?.gunPoseActive).toBe(true);
+    expect(results[2]?.shotFired).toBe(false);
+  });
+
+  it("blocks fire on a low-confidence pull frame but keeps the pose visible", () => {
+    const lowConfidencePullFrame = withThumbTriggerPose(withLowConfidenceGunPose(frame), "pulled");
+    const lowConfidenceMeasurement = measureGunPose(lowConfidencePullFrame);
+    const results = runInputSequence([
+      withThumbTriggerPose(frame, "open"),
+      withThumbTriggerPose(frame, "open"),
+      withThumbTriggerPose(frame, "open"),
+      withThumbTriggerPose(frame, "pulled"),
+      lowConfidencePullFrame,
+      withThumbTriggerPose(frame, "pulled")
+    ]);
+
+    expect(lowConfidenceMeasurement.detected).toBe(false);
+    expect(lowConfidenceMeasurement.confidence).toBeGreaterThanOrEqual(0.45);
+    expect(lowConfidenceMeasurement.confidence).toBeLessThan(0.55);
+    expect(results[4]?.gunPoseActive).toBe(true);
+    expect(results[4]?.shotFired).toBe(false);
+    expect(results[5]?.shotFired).toBe(true);
   });
 
   it("keeps the smoother between the previous crosshair and the raw target", () => {
@@ -110,11 +248,85 @@ describe("mapHandToGameInput", () => {
 
   it("maps the index finger to mirrored viewport coordinates", () => {
     const result = mapHandToGameInput(frame, { width: 1280, height: 720 }, undefined);
-    expect(result.crosshair.x).toBeCloseTo(640, 0);
-    expect(result.crosshair.y).toBeCloseTo(168, 0);
+    const crosshair = expectDefined(result.crosshair, "Expected crosshair");
+
+    expect(crosshair.x).toBeCloseTo(640, 0);
+    expect(crosshair.y).toBeCloseTo(168, 0);
   });
 
-  it("only emits a shot when a loose gun pose and trigger pull occur", () => {
+  describe("issue-30 interaction contract", () => {
+    it("one intentional pull emits exactly one shot", () => {
+      const results = runIssue30Sequence([
+        { pose: "open" },
+        { pose: "open" },
+        { pose: "pulled" },
+        { pose: "pulled" }
+      ]);
+
+      expect(results.filter((result) => result.shotFired)).toHaveLength(1);
+      expect(results[3]?.shotFired).toBe(true);
+    });
+
+    it("held pull does not auto-repeat", () => {
+      const results = runIssue30Sequence([
+        { pose: "open" },
+        { pose: "open" },
+        { pose: "pulled" },
+        { pose: "pulled" },
+        { pose: "pulled" },
+        { pose: "pulled" }
+      ]);
+
+      expect(results.filter((result) => result.shotFired)).toHaveLength(1);
+      expect(results.at(-1)?.shotFired).toBe(false);
+    });
+
+    it("brief thumb jitter does not emit", () => {
+      const results = runIssue30Sequence([
+        { pose: "open" },
+        { pose: "open" },
+        { pose: "pulled" },
+        { pose: "pulled" },
+        { pose: "open" },
+        { pose: "pulled" },
+        { pose: "pulled" }
+      ]);
+
+      expect(results.filter((result) => result.shotFired)).toHaveLength(1);
+      expect(results[4]?.triggerState).toBe("pulled");
+      expect(results[6]?.shotFired).toBe(false);
+    });
+
+    it("brief pose drop does not instantly cancel a valid armed state", () => {
+      const results = runIssue30Sequence([
+        { pose: "open" },
+        { pose: "open" },
+        { pose: "pulled" },
+        { pose: "pulled", gunPoseActive: false },
+        { pose: "pulled" }
+      ]);
+
+      expect(results[3]?.gunPoseActive).toBe(true);
+      expect(results[4]?.gunPoseActive).toBe(true);
+      expect(results.filter((result) => result.shotFired)).toHaveLength(1);
+    });
+
+    it("tracking reacquisition alone does not emit", () => {
+      const results = runIssue30Sequence([
+        { pose: "open" },
+        { pose: "open", gunPoseActive: false },
+        { pose: "pulled", gunPoseActive: false },
+        { pose: "pulled", gunPoseActive: false },
+        { pose: "pulled" }
+      ]);
+
+      expect(results[4]?.gunPoseActive).toBe(true);
+      expect(results[4]?.triggerState).toBe("pulled");
+      expect(results.filter((result) => result.shotFired)).toHaveLength(0);
+    });
+  });
+
+  it("intentional single-shot: open -> stable pulled transition emits exactly once", () => {
     const openFrame = frame;
     const pulledFrame = withThumbTriggerPose(frame, "pulled");
     const armedRuntime = createArmedRuntime();
@@ -167,6 +379,25 @@ describe("mapHandToGameInput", () => {
     expect(nonGunPulled.shotFired).toBe(false);
   });
 
+  it("tracking-loss/reacquisition non-fire: lost pose + reacquire does not generate a shot", () => {
+    const sequence = runInputSequence(
+      [
+        withGunPose(withThumbTriggerPose(frame, "open"), false),
+        withGunPose(withThumbTriggerPose(frame, "open"), false),
+        withGunPose(withThumbTriggerPose(frame, "pulled"), false),
+        withGunPose(withThumbTriggerPose(frame, "pulled"), false),
+        withThumbTriggerPose(frame, "pulled")
+      ],
+      createArmedRuntime()
+    );
+
+    expect(sequence[2]?.shotFired).toBe(false);
+    expect(sequence[3]?.shotFired).toBe(false);
+    expect(sequence[4]?.shotFired).toBe(false);
+    expect(sequence[4]?.gunPoseActive).toBe(true);
+    expect(sequence[4]?.triggerState).toBe("pulled");
+  });
+
   it("clamps the mirrored crosshair to the canvas bounds", () => {
     const result = mapHandToGameInput(
       {
@@ -180,8 +411,9 @@ describe("mapHandToGameInput", () => {
       undefined
     );
 
-    expect(result.crosshair.x).toBe(0);
-    expect(result.crosshair.y).toBe(0);
+    const crosshair = expectDefined(result.crosshair, "Expected clamped crosshair");
+
+    expect(crosshair).toEqual({ x: 0, y: 0 });
   });
 
   it("smooths crosshair motion instead of snapping raw coordinates", () => {
@@ -197,9 +429,16 @@ describe("mapHandToGameInput", () => {
       canvasSize,
       first.runtime
     );
+    const firstCrosshair = first.crosshair;
+    const secondCrosshair = second.crosshair;
 
-    expect(second.crosshair.x).toBeLessThan(first.crosshair.x);
-    expect(second.crosshair.x).toBeGreaterThan(256);
+    expect(firstCrosshair).toBeDefined();
+    expect(secondCrosshair).toBeDefined();
+    const definedFirstCrosshair = expectDefined(firstCrosshair, "Expected first crosshair");
+    const definedSecondCrosshair = expectDefined(secondCrosshair, "Expected second crosshair");
+
+    expect(definedSecondCrosshair.x).toBeLessThan(definedFirstCrosshair.x);
+    expect(definedSecondCrosshair.x).toBeGreaterThan(256);
   });
 
   it("accepts runtime tuning values for smoothing and trigger hysteresis", () => {
@@ -237,8 +476,10 @@ describe("mapHandToGameInput", () => {
       third.runtime,
       tuning
     );
+    const secondCrosshair = second.crosshair;
 
-    expect(second.crosshair.x).toBeCloseTo(448, 0);
+    expect(secondCrosshair).toBeDefined();
+    expect(expectDefined(secondCrosshair, "Expected crosshair").x).toBeCloseTo(448, 0);
     expect(second.shotFired).toBe(false);
     expect(third.shotFired).toBe(true);
     expect(fourth.triggerState).toBe("pulled");
@@ -268,7 +509,7 @@ describe("mapHandToGameInput", () => {
     expect(results[3]?.shotFired).toBe(true);
   });
 
-  it("keeps a valid shot when gun pose drops for one frame during the pull", () => {
+  it("pose-drop tolerance: keep valid shot when gun pose drops for one frame during pull", () => {
     const results = runInputSequence([
       withGunPose(withThumbTriggerPose(frame, "open"), true),
       withGunPose(withThumbTriggerPose(frame, "open"), true),
@@ -280,7 +521,7 @@ describe("mapHandToGameInput", () => {
     expect(results[3]?.gunPoseActive).toBe(true);
   });
 
-  it("does not auto-repeat while the trigger stays held", () => {
+  it("hold suppression: no repeated shots while trigger stays held", () => {
     const results = runInputSequence([
       withThumbTriggerPose(frame, "open"),
       withThumbTriggerPose(frame, "open"),
@@ -292,7 +533,7 @@ describe("mapHandToGameInput", () => {
     expect(results.filter((result) => result.shotFired)).toHaveLength(1);
   });
 
-  it("keeps the trigger latched through a single open-frame jitter", () => {
+  it("jitter suppression: keep trigger latched through a single open-frame jitter", () => {
     const results = runInputSequence([
       withThumbTriggerPose(frame, "open"),
       withThumbTriggerPose(frame, "pulled"),
@@ -305,44 +546,46 @@ describe("mapHandToGameInput", () => {
     expect(results[4]?.shotFired).toBe(false);
   });
 
-  it("requires a real release before firing again", () => {
-    const results = runInputSequence([
-      withThumbTriggerPose(frame, "open"),
-      withThumbTriggerPose(frame, "open"),
-      withThumbTriggerPose(frame, "pulled"),
-      withThumbTriggerPose(frame, "pulled"),
-      withThumbTriggerPose(frame, "open"),
-      withThumbTriggerPose(frame, "open"),
-      withThumbTriggerPose(frame, "pulled"),
-      withThumbTriggerPose(frame, "pulled")
-    ], createArmedRuntime());
+    it("requires a full open cycle before firing again after release", () => {
+      const results = runInputSequence(
+        [
+          withThumbTriggerPose(frame, "open"),
+          withThumbTriggerPose(frame, "open"),
+          withThumbTriggerPose(frame, "open"),
+          withThumbTriggerPose(frame, "pulled"),
+          withThumbTriggerPose(frame, "pulled"),
+          withThumbTriggerPose(frame, "open"),
+          withThumbTriggerPose(frame, "open"),
+          withThumbTriggerPose(frame, "open"),
+          withThumbTriggerPose(frame, "pulled"),
+          withThumbTriggerPose(frame, "pulled")
+        ],
+        createArmedRuntime()
+      );
 
     expect(results.filter((result) => result.shotFired)).toHaveLength(2);
-    expect(results[5]?.triggerState).toBe("open");
-    expect(results[7]?.shotFired).toBe(true);
+    expect(results[9]?.shotFired).toBe(true);
   });
 
-  it("does not fire after reset until a released trigger has been observed", () => {
-    const heldAtStart = runInputSequence([
-      withThumbTriggerPose(frame, "pulled"),
-      withThumbTriggerPose(frame, "pulled")
-    ]);
-    const noisyRelease = runInputSequence([
-      withThumbTriggerPose(frame, "pulled"),
-      withThumbTriggerPose(frame, "open"),
-      withThumbTriggerPose(frame, "pulled"),
-      withThumbTriggerPose(frame, "pulled")
-    ]);
-    const armedSequence = runInputSequence([
-      withThumbTriggerPose(frame, "open"),
-      withThumbTriggerPose(frame, "open"),
-      withThumbTriggerPose(frame, "pulled"),
-      withThumbTriggerPose(frame, "pulled")
-    ]);
-
-    expect(heldAtStart.some((result) => result.shotFired)).toBe(false);
-    expect(noisyRelease.some((result) => result.shotFired)).toBe(false);
-    expect(armedSequence.filter((result) => result.shotFired)).toHaveLength(1);
-    expect(armedSequence[3]?.shotFired).toBe(true);
-  });
+    it("cold-start open-open-pulled-pulled does not fire", () => {
+      const coldStart = runInputSequence([
+        withThumbTriggerPose(frame, "open"),
+        withThumbTriggerPose(frame, "open"),
+        withThumbTriggerPose(frame, "pulled"),
+        withThumbTriggerPose(frame, "pulled")
+      ]);
+      const heldAtStart = runInputSequence([
+        withThumbTriggerPose(frame, "pulled"),
+        withThumbTriggerPose(frame, "pulled")
+      ]);
+      const noisyRelease = runInputSequence([
+        withThumbTriggerPose(frame, "pulled"),
+        withThumbTriggerPose(frame, "open"),
+        withThumbTriggerPose(frame, "pulled"),
+        withThumbTriggerPose(frame, "pulled")
+      ]);
+      expect(coldStart.some((result) => result.shotFired)).toBe(false);
+      expect(heldAtStart.some((result) => result.shotFired)).toBe(false);
+      expect(noisyRelease.some((result) => result.shotFired)).toBe(false);
+    });
 });

--- a/tests/unit/features/input-mapping/mapHandToGameInput.test.ts
+++ b/tests/unit/features/input-mapping/mapHandToGameInput.test.ts
@@ -141,7 +141,7 @@ describe("mapHandToGameInput", () => {
 
   it("turns missing tracking into tracking_lost and clears the crosshair", () => {
     const result = mapHandToGameInput(
-      undefined as unknown as HandFrame,
+      undefined,
       canvasSize,
       createArmedRuntime()
     );
@@ -214,7 +214,7 @@ describe("mapHandToGameInput", () => {
 
     expect(lowConfidenceMeasurement.detected).toBe(false);
     expect(lowConfidenceMeasurement.confidence).toBeGreaterThanOrEqual(0.45);
-    expect(lowConfidenceMeasurement.confidence).toBeLessThan(0.55);
+    expect(lowConfidenceMeasurement.confidence).toBeLessThanOrEqual(0.55);
     expect(results[4]?.gunPoseActive).toBe(true);
     expect(results[4]?.shotFired).toBe(false);
     expect(results[5]?.shotFired).toBe(true);

--- a/tests/unit/features/input-mapping/mapHandToGameInput.test.ts
+++ b/tests/unit/features/input-mapping/mapHandToGameInput.test.ts
@@ -306,8 +306,6 @@ describe("mapHandToGameInput", () => {
     ]);
 
     expect(lowConfidenceMeasurement.detected).toBe(false);
-    expect(lowConfidenceMeasurement.confidence).toBeGreaterThanOrEqual(0.45);
-    expect(lowConfidenceMeasurement.confidence).toBeLessThanOrEqual(0.55);
     expect(results[4]?.gunPoseActive).toBe(true);
     expect(results[4]?.shotFired).toBe(false);
     expect(results[5]?.shotFired).toBe(true);

--- a/tests/unit/features/input-mapping/mapHandToGameInput.test.ts
+++ b/tests/unit/features/input-mapping/mapHandToGameInput.test.ts
@@ -57,8 +57,16 @@ const createArmedRuntime = (
     first.runtime,
     tuning
   );
+  const third = mapHandToGameInput(
+    withThumbTriggerPose(frame, "open"),
+    canvasSize,
+    second.runtime,
+    tuning
+  );
 
-  return second.runtime;
+  expect(third.runtime.phase).toBe("armed");
+
+  return third.runtime;
 };
 
 const withGunPose = (inputFrame: HandFrame, active: boolean): HandFrame =>
@@ -103,6 +111,91 @@ const runIssue30Sequence = (
     steps.map(({ pose, gunPoseActive = true }) => createIssue30Frame(pose, gunPoseActive)),
     initialRuntime
   );
+
+interface Issue30ContractScenario {
+  name: string;
+  steps: Issue30FrameStep[];
+  initialRuntime?: GameInputFrame["runtime"];
+  assert: (results: GameInputFrame[]) => void;
+}
+
+const issue30ContractScenarios: Issue30ContractScenario[] = [
+  {
+    name: "one intentional pull emits exactly one shot",
+    steps: [
+      { pose: "open" },
+      { pose: "open" },
+      { pose: "pulled" },
+      { pose: "pulled" }
+    ],
+    assert: (results) => {
+      expect(results.filter((result) => result.shotFired)).toHaveLength(1);
+      expect(results[3]?.shotFired).toBe(true);
+    }
+  },
+  {
+    name: "held pull does not auto-repeat",
+    steps: [
+      { pose: "open" },
+      { pose: "open" },
+      { pose: "pulled" },
+      { pose: "pulled" },
+      { pose: "pulled" },
+      { pose: "pulled" }
+    ],
+    assert: (results) => {
+      expect(results.filter((result) => result.shotFired)).toHaveLength(1);
+      expect(results.at(-1)?.shotFired).toBe(false);
+    }
+  },
+  {
+    name: "brief thumb jitter does not emit",
+    steps: [
+      { pose: "open" },
+      { pose: "open" },
+      { pose: "pulled" },
+      { pose: "pulled" },
+      { pose: "open" },
+      { pose: "pulled" },
+      { pose: "pulled" }
+    ],
+    assert: (results) => {
+      expect(results.filter((result) => result.shotFired)).toHaveLength(1);
+      expect(results[4]?.triggerState).toBe("pulled");
+      expect(results[6]?.shotFired).toBe(false);
+    }
+  },
+  {
+    name: "brief pose drop does not instantly cancel a valid armed state",
+    steps: [
+      { pose: "open" },
+      { pose: "open" },
+      { pose: "pulled" },
+      { pose: "pulled", gunPoseActive: false },
+      { pose: "pulled" }
+    ],
+    assert: (results) => {
+      expect(results[3]?.gunPoseActive).toBe(true);
+      expect(results[4]?.gunPoseActive).toBe(true);
+      expect(results.filter((result) => result.shotFired)).toHaveLength(1);
+    }
+  },
+  {
+    name: "tracking reacquisition alone does not emit",
+    steps: [
+      { pose: "open" },
+      { pose: "open", gunPoseActive: false },
+      { pose: "pulled", gunPoseActive: false },
+      { pose: "pulled", gunPoseActive: false },
+      { pose: "pulled" }
+    ],
+    assert: (results) => {
+      expect(results[4]?.gunPoseActive).toBe(true);
+      expect(results[4]?.triggerState).toBe("pulled");
+      expect(results.filter((result) => result.shotFired)).toHaveLength(0);
+    }
+  }
+];
 
 describe("mapHandToGameInput", () => {
   it("builds hand evidence without conflating tracking presence with trigger state", () => {
@@ -255,107 +348,11 @@ describe("mapHandToGameInput", () => {
   });
 
   describe("issue-30 interaction contract", () => {
-    it("one intentional pull emits exactly one shot", () => {
-      const results = runIssue30Sequence([
-        { pose: "open" },
-        { pose: "open" },
-        { pose: "pulled" },
-        { pose: "pulled" }
-      ]);
+    it.each(issue30ContractScenarios)("$name", ({ steps, initialRuntime, assert }) => {
+      const results = runIssue30Sequence(steps, initialRuntime);
 
-      expect(results.filter((result) => result.shotFired)).toHaveLength(1);
-      expect(results[3]?.shotFired).toBe(true);
+      assert(results);
     });
-
-    it("held pull does not auto-repeat", () => {
-      const results = runIssue30Sequence([
-        { pose: "open" },
-        { pose: "open" },
-        { pose: "pulled" },
-        { pose: "pulled" },
-        { pose: "pulled" },
-        { pose: "pulled" }
-      ]);
-
-      expect(results.filter((result) => result.shotFired)).toHaveLength(1);
-      expect(results.at(-1)?.shotFired).toBe(false);
-    });
-
-    it("brief thumb jitter does not emit", () => {
-      const results = runIssue30Sequence([
-        { pose: "open" },
-        { pose: "open" },
-        { pose: "pulled" },
-        { pose: "pulled" },
-        { pose: "open" },
-        { pose: "pulled" },
-        { pose: "pulled" }
-      ]);
-
-      expect(results.filter((result) => result.shotFired)).toHaveLength(1);
-      expect(results[4]?.triggerState).toBe("pulled");
-      expect(results[6]?.shotFired).toBe(false);
-    });
-
-    it("brief pose drop does not instantly cancel a valid armed state", () => {
-      const results = runIssue30Sequence([
-        { pose: "open" },
-        { pose: "open" },
-        { pose: "pulled" },
-        { pose: "pulled", gunPoseActive: false },
-        { pose: "pulled" }
-      ]);
-
-      expect(results[3]?.gunPoseActive).toBe(true);
-      expect(results[4]?.gunPoseActive).toBe(true);
-      expect(results.filter((result) => result.shotFired)).toHaveLength(1);
-    });
-
-    it("tracking reacquisition alone does not emit", () => {
-      const results = runIssue30Sequence([
-        { pose: "open" },
-        { pose: "open", gunPoseActive: false },
-        { pose: "pulled", gunPoseActive: false },
-        { pose: "pulled", gunPoseActive: false },
-        { pose: "pulled" }
-      ]);
-
-      expect(results[4]?.gunPoseActive).toBe(true);
-      expect(results[4]?.triggerState).toBe("pulled");
-      expect(results.filter((result) => result.shotFired)).toHaveLength(0);
-    });
-  });
-
-  it("intentional single-shot: open -> stable pulled transition emits exactly once", () => {
-    const openFrame = frame;
-    const pulledFrame = withThumbTriggerPose(frame, "pulled");
-    const armedRuntime = createArmedRuntime();
-
-    const first = mapHandToGameInput(
-      openFrame,
-      canvasSize,
-      armedRuntime
-    );
-    const second = mapHandToGameInput(
-      pulledFrame,
-      canvasSize,
-      first.runtime
-    );
-    const third = mapHandToGameInput(
-      pulledFrame,
-      canvasSize,
-      second.runtime
-    );
-    const fourth = mapHandToGameInput(
-      pulledFrame,
-      canvasSize,
-      third.runtime
-    );
-
-    expect(first.shotFired).toBe(false);
-    expect(second.shotFired).toBe(false);
-    expect(third.shotFired).toBe(true);
-    expect(fourth.shotFired).toBe(false);
   });
 
   it("does not emit a shot on open -> pulled when gun pose is inactive", () => {
@@ -377,25 +374,6 @@ describe("mapHandToGameInput", () => {
 
     expect(nonGunOpen.shotFired).toBe(false);
     expect(nonGunPulled.shotFired).toBe(false);
-  });
-
-  it("tracking-loss/reacquisition non-fire: lost pose + reacquire does not generate a shot", () => {
-    const sequence = runInputSequence(
-      [
-        withGunPose(withThumbTriggerPose(frame, "open"), false),
-        withGunPose(withThumbTriggerPose(frame, "open"), false),
-        withGunPose(withThumbTriggerPose(frame, "pulled"), false),
-        withGunPose(withThumbTriggerPose(frame, "pulled"), false),
-        withThumbTriggerPose(frame, "pulled")
-      ],
-      createArmedRuntime()
-    );
-
-    expect(sequence[2]?.shotFired).toBe(false);
-    expect(sequence[3]?.shotFired).toBe(false);
-    expect(sequence[4]?.shotFired).toBe(false);
-    expect(sequence[4]?.gunPoseActive).toBe(true);
-    expect(sequence[4]?.triggerState).toBe("pulled");
   });
 
   it("clamps the mirrored crosshair to the canvas bounds", () => {
@@ -496,96 +474,46 @@ describe("mapHandToGameInput", () => {
     expect(results.at(-1)?.triggerState).toBe("open");
   });
 
-  it("fires once after the pull stays stable for two frames", () => {
-    const results = runInputSequence([
-      withThumbTriggerPose(frame, "open"),
-      withThumbTriggerPose(frame, "open"),
-      withThumbTriggerPose(frame, "pulled"),
-      withThumbTriggerPose(frame, "pulled")
-    ], createArmedRuntime());
-
-    expect(results[1]?.shotFired).toBe(false);
-    expect(results[2]?.shotFired).toBe(false);
-    expect(results[3]?.shotFired).toBe(true);
-  });
-
-  it("pose-drop tolerance: keep valid shot when gun pose drops for one frame during pull", () => {
-    const results = runInputSequence([
-      withGunPose(withThumbTriggerPose(frame, "open"), true),
-      withGunPose(withThumbTriggerPose(frame, "open"), true),
-      withGunPose(withThumbTriggerPose(frame, "pulled"), false),
-      withGunPose(withThumbTriggerPose(frame, "pulled"), true)
-    ], createArmedRuntime());
-
-    expect(results[3]?.shotFired).toBe(true);
-    expect(results[3]?.gunPoseActive).toBe(true);
-  });
-
-  it("hold suppression: no repeated shots while trigger stays held", () => {
-    const results = runInputSequence([
-      withThumbTriggerPose(frame, "open"),
-      withThumbTriggerPose(frame, "open"),
-      withThumbTriggerPose(frame, "pulled"),
-      withThumbTriggerPose(frame, "pulled"),
-      withThumbTriggerPose(frame, "pulled")
-    ], createArmedRuntime());
-
-    expect(results.filter((result) => result.shotFired)).toHaveLength(1);
-  });
-
-  it("jitter suppression: keep trigger latched through a single open-frame jitter", () => {
-    const results = runInputSequence([
-      withThumbTriggerPose(frame, "open"),
-      withThumbTriggerPose(frame, "pulled"),
-      withThumbTriggerPose(frame, "pulled"),
-      withThumbTriggerPose(frame, "open"),
-      withThumbTriggerPose(frame, "pulled")
-    ]);
-
-    expect(results[3]?.triggerState).toBe("pulled");
-    expect(results[4]?.shotFired).toBe(false);
-  });
-
-    it("requires a full open cycle before firing again after release", () => {
-      const results = runInputSequence(
-        [
-          withThumbTriggerPose(frame, "open"),
-          withThumbTriggerPose(frame, "open"),
-          withThumbTriggerPose(frame, "open"),
-          withThumbTriggerPose(frame, "pulled"),
-          withThumbTriggerPose(frame, "pulled"),
-          withThumbTriggerPose(frame, "open"),
-          withThumbTriggerPose(frame, "open"),
-          withThumbTriggerPose(frame, "open"),
-          withThumbTriggerPose(frame, "pulled"),
-          withThumbTriggerPose(frame, "pulled")
-        ],
-        createArmedRuntime()
-      );
+  it("requires a full open cycle before firing again after release", () => {
+    const results = runInputSequence(
+      [
+        withThumbTriggerPose(frame, "open"),
+        withThumbTriggerPose(frame, "open"),
+        withThumbTriggerPose(frame, "open"),
+        withThumbTriggerPose(frame, "pulled"),
+        withThumbTriggerPose(frame, "pulled"),
+        withThumbTriggerPose(frame, "open"),
+        withThumbTriggerPose(frame, "open"),
+        withThumbTriggerPose(frame, "open"),
+        withThumbTriggerPose(frame, "pulled"),
+        withThumbTriggerPose(frame, "pulled")
+      ],
+      createArmedRuntime()
+    );
 
     expect(results.filter((result) => result.shotFired)).toHaveLength(2);
     expect(results[9]?.shotFired).toBe(true);
   });
 
-    it("cold-start open-open-pulled-pulled does not fire", () => {
-      const coldStart = runInputSequence([
-        withThumbTriggerPose(frame, "open"),
-        withThumbTriggerPose(frame, "open"),
-        withThumbTriggerPose(frame, "pulled"),
-        withThumbTriggerPose(frame, "pulled")
-      ]);
-      const heldAtStart = runInputSequence([
-        withThumbTriggerPose(frame, "pulled"),
-        withThumbTriggerPose(frame, "pulled")
-      ]);
-      const noisyRelease = runInputSequence([
-        withThumbTriggerPose(frame, "pulled"),
-        withThumbTriggerPose(frame, "open"),
-        withThumbTriggerPose(frame, "pulled"),
-        withThumbTriggerPose(frame, "pulled")
-      ]);
-      expect(coldStart.some((result) => result.shotFired)).toBe(false);
-      expect(heldAtStart.some((result) => result.shotFired)).toBe(false);
-      expect(noisyRelease.some((result) => result.shotFired)).toBe(false);
-    });
+  it("cold-start open-open-pulled-pulled does not fire", () => {
+    const coldStart = runInputSequence([
+      withThumbTriggerPose(frame, "open"),
+      withThumbTriggerPose(frame, "open"),
+      withThumbTriggerPose(frame, "pulled"),
+      withThumbTriggerPose(frame, "pulled")
+    ]);
+    const heldAtStart = runInputSequence([
+      withThumbTriggerPose(frame, "pulled"),
+      withThumbTriggerPose(frame, "pulled")
+    ]);
+    const noisyRelease = runInputSequence([
+      withThumbTriggerPose(frame, "pulled"),
+      withThumbTriggerPose(frame, "open"),
+      withThumbTriggerPose(frame, "pulled"),
+      withThumbTriggerPose(frame, "pulled")
+    ]);
+    expect(coldStart.some((result) => result.shotFired)).toBe(false);
+    expect(heldAtStart.some((result) => result.shotFired)).toBe(false);
+    expect(noisyRelease.some((result) => result.shotFired)).toBe(false);
+  });
 });

--- a/tests/unit/features/input-mapping/shotIntentStateMachine.test.ts
+++ b/tests/unit/features/input-mapping/shotIntentStateMachine.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from "vitest";
+import {
+  advanceShotIntentState,
+  type ShotIntentResult,
+  type ShotIntentState
+} from "../../../../src/features/input-mapping/shotIntentStateMachine";
+import type { HandEvidence } from "../../../../src/features/input-mapping/createHandEvidence";
+import type { TriggerState } from "../../../../src/features/input-mapping/evaluateThumbTrigger";
+
+const FIRE_ENTRY_GUN_POSE_CONFIDENCE = 0.55;
+const FIRE_EXIT_GUN_POSE_CONFIDENCE = 0.45;
+
+const createEvidence = ({
+  trackingPresent = true,
+  triggerState = "open",
+  gunPoseConfidence = FIRE_ENTRY_GUN_POSE_CONFIDENCE
+}: {
+  trackingPresent?: boolean;
+  triggerState?: TriggerState;
+  gunPoseConfidence?: number;
+} = {}): HandEvidence => ({
+  trackingPresent,
+  frameAtMs: undefined,
+  smoothedCrosshairCandidate: null,
+  trigger: trackingPresent
+    ? {
+        rawState: triggerState,
+        confidence: 1,
+        details: {
+          projection: 0.25,
+          pullThreshold: 0.18,
+          releaseThreshold: 0.1
+        }
+      }
+    : null,
+  gunPose: trackingPresent
+    ? {
+        detected: gunPoseConfidence >= FIRE_ENTRY_GUN_POSE_CONFIDENCE,
+        confidence: gunPoseConfidence,
+        details: {
+          indexExtended: true,
+          curledFingerCount: 2,
+          curledThreshold: 0.25
+        }
+      }
+    : null
+});
+
+const runSequence = (steps: Parameters<typeof createEvidence>[0][]): ShotIntentResult[] => {
+  const results: ShotIntentResult[] = [];
+  let state: ShotIntentState | undefined;
+
+  for (const step of steps) {
+    const result = advanceShotIntentState(state, createEvidence(step));
+    results.push(result);
+    state = result.state;
+  }
+
+  return results;
+};
+
+describe("ShotIntentStateMachine", () => {
+  it("promotes idle to ready and ready to armed after three stable open frames", () => {
+    const [first, second, third] = runSequence([
+      { triggerState: "open" },
+      { triggerState: "open" },
+      { triggerState: "open" }
+    ]);
+
+    expect(first?.state.phase).toBe("idle");
+    expect(first?.state.rejectReason).toBe("waiting_for_stable_open");
+    expect(first?.shotFired).toBe(false);
+
+    expect(second?.state.phase).toBe("ready");
+    expect(second?.state.rejectReason).toBe("waiting_for_fire_entry");
+    expect(second?.shotFired).toBe(false);
+
+    expect(third?.state.phase).toBe("armed");
+    expect(third?.state.rejectReason).toBe("waiting_for_stable_pulled");
+    expect(third?.shotFired).toBe(false);
+  });
+
+  it("does not fire on a cold-start open-open-pulled-pulled sequence", () => {
+    const results = runSequence([
+      { triggerState: "open" },
+      { triggerState: "open" },
+      { triggerState: "pulled" },
+      { triggerState: "pulled" }
+    ]);
+
+    expect(results.map((result) => result.state.phase)).toEqual(["idle", "ready", "ready", "ready"]);
+    expect(results.some((result) => result.shotFired)).toBe(false);
+  });
+
+  it("emits shotFired exactly once on armed to fired and returns to ready after recovering", () => {
+    const [first, second, third, fourth, fifth, sixth, seventh] = runSequence([
+      { triggerState: "open" },
+      { triggerState: "open" },
+      { triggerState: "open" },
+      { triggerState: "pulled" },
+      { triggerState: "pulled" },
+      { triggerState: "open" },
+      { triggerState: "open" }
+    ]);
+
+    expect(first?.state.phase).toBe("idle");
+    expect(second?.state.phase).toBe("ready");
+    expect(third?.state.phase).toBe("armed");
+    expect(fourth?.state.phase).toBe("armed");
+    expect(fifth?.state.phase).toBe("fired");
+    expect(fifth?.shotFired).toBe(true);
+    expect(sixth?.state.phase).toBe("recovering");
+    expect(sixth?.shotFired).toBe(false);
+    expect(seventh?.state.phase).toBe("ready");
+    expect(seventh?.shotFired).toBe(false);
+
+    expect(runSequence([
+      { triggerState: "open" },
+      { triggerState: "open" },
+      { triggerState: "open" },
+      { triggerState: "pulled" },
+      { triggerState: "pulled" },
+      { triggerState: "pulled" },
+      { triggerState: "pulled" }
+    ]).filter((result) => result.shotFired)).toHaveLength(1);
+  });
+
+  it("enters tracking_lost immediately and does not re-arm until two tracking-present frames arrive", () => {
+    const [first, second, third, fourth, fifth, sixth, seventh] = runSequence([
+      { triggerState: "open" },
+      { triggerState: "open" },
+      { trackingPresent: false },
+      { triggerState: "open" },
+      { triggerState: "open" },
+      { triggerState: "pulled" },
+      { triggerState: "pulled" }
+    ]);
+
+    expect(first?.state.phase).toBe("idle");
+    expect(second?.state.phase).toBe("ready");
+    expect(third?.state.phase).toBe("tracking_lost");
+    expect(third?.state.rejectReason).toBe("tracking_lost");
+    expect(third?.shotFired).toBe(false);
+    expect(fourth?.state.phase).toBe("tracking_lost");
+    expect(fifth?.state.phase).toBe("idle");
+    expect(sixth?.state.phase).toBe("idle");
+    expect(seventh?.state.phase).toBe("idle");
+    expect(runSequence([
+      { triggerState: "open" },
+      { triggerState: "open" },
+      { trackingPresent: false },
+      { triggerState: "open" },
+      { triggerState: "open" },
+      { triggerState: "pulled" },
+      { triggerState: "pulled" }
+    ]).some((result) => result.shotFired)).toBe(false);
+  });
+
+  it("keeps reject reasons separate from phases", () => {
+    const idleResult = advanceShotIntentState(undefined, createEvidence({ triggerState: "open" }));
+    const lostResult = advanceShotIntentState(idleResult.state, createEvidence({ trackingPresent: false }));
+
+    expect(idleResult.state.phase).toBe("idle");
+    expect(idleResult.state.rejectReason).toBe("waiting_for_stable_open");
+    expect(idleResult.state.rejectReason).not.toBe(idleResult.state.phase);
+
+    expect(lostResult.state.phase).toBe("tracking_lost");
+    expect(lostResult.state.rejectReason).toBe("tracking_lost");
+    expect(lostResult.state.rejectReason).not.toBe("idle");
+  });
+
+  it("keeps pose visible but blocks fire until confidence recovers above the entry threshold", () => {
+    const [first, second, third, fourth, fifth, sixth] = runSequence([
+      { triggerState: "open", gunPoseConfidence: FIRE_ENTRY_GUN_POSE_CONFIDENCE },
+      { triggerState: "open", gunPoseConfidence: FIRE_ENTRY_GUN_POSE_CONFIDENCE },
+      { triggerState: "open", gunPoseConfidence: FIRE_ENTRY_GUN_POSE_CONFIDENCE },
+      { triggerState: "pulled", gunPoseConfidence: FIRE_ENTRY_GUN_POSE_CONFIDENCE },
+      { triggerState: "pulled", gunPoseConfidence: FIRE_EXIT_GUN_POSE_CONFIDENCE },
+      { triggerState: "pulled", gunPoseConfidence: FIRE_ENTRY_GUN_POSE_CONFIDENCE }
+    ]);
+
+    expect(first?.state.phase).toBe("idle");
+    expect(second?.state.phase).toBe("ready");
+    expect(third?.state.phase).toBe("armed");
+    expect(fourth?.state.phase).toBe("armed");
+    expect(fourth?.shotFired).toBe(false);
+    expect(fifth?.state.phase).not.toBe("tracking_lost");
+    expect(fifth?.state.phase).toBe("armed");
+    expect(fifth?.state.gunPoseActive).toBe(true);
+    expect(fifth?.shotFired).toBe(false);
+    expect(sixth?.state.phase).toBe("fired");
+    expect(sixth?.shotFired).toBe(true);
+  });
+});

--- a/tests/unit/features/input-mapping/trackingLoss.test.ts
+++ b/tests/unit/features/input-mapping/trackingLoss.test.ts
@@ -66,8 +66,9 @@ const createArmedRuntime = (): GameInputFrame["runtime"] => {
   const openFrame = withThumbTriggerPose(createThumbTriggerFrame("open"), "open");
   const first = mapHandToGameInput(openFrame, canvasSize, undefined, gameConfig.input);
   const second = mapHandToGameInput(openFrame, canvasSize, first.runtime, gameConfig.input);
+  const third = mapHandToGameInput(openFrame, canvasSize, second.runtime, gameConfig.input);
 
-  return second.runtime;
+  return third.runtime;
 };
 
 describe("tracking loss", () => {

--- a/tests/unit/features/input-mapping/trackingLoss.test.ts
+++ b/tests/unit/features/input-mapping/trackingLoss.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+import { createThumbTriggerFrame, withThumbTriggerPose } from "./thumbTriggerTestHelper";
+import { gameConfig } from "../../../../src/shared/config/gameConfig";
+import { mapHandToGameInput, type GameInputFrame } from "../../../../src/features/input-mapping/mapHandToGameInput";
+import {
+  advanceShotIntentState,
+  type ShotIntentState
+} from "../../../../src/features/input-mapping/shotIntentStateMachine";
+import type { HandEvidence } from "../../../../src/features/input-mapping/createHandEvidence";
+import type { TriggerState } from "../../../../src/features/input-mapping/evaluateThumbTrigger";
+
+const FIRE_ENTRY_GUN_POSE_CONFIDENCE = 0.55;
+
+const createEvidence = ({
+  trackingPresent = true,
+  triggerState = "open",
+  gunPoseConfidence = FIRE_ENTRY_GUN_POSE_CONFIDENCE
+}: {
+  trackingPresent?: boolean;
+  triggerState?: TriggerState;
+  gunPoseConfidence?: number;
+} = {}): HandEvidence => ({
+  trackingPresent,
+  frameAtMs: undefined,
+  smoothedCrosshairCandidate: null,
+  trigger: trackingPresent
+    ? {
+        rawState: triggerState,
+        confidence: 1,
+        details: {
+          projection: 0.25,
+          pullThreshold: 0.18,
+          releaseThreshold: 0.1
+        }
+      }
+    : null,
+  gunPose: trackingPresent
+    ? {
+        detected: gunPoseConfidence >= FIRE_ENTRY_GUN_POSE_CONFIDENCE,
+        confidence: gunPoseConfidence,
+        details: {
+          indexExtended: true,
+          curledFingerCount: 2,
+          curledThreshold: 0.25
+        }
+      }
+    : null
+});
+
+const runSequence = (steps: Parameters<typeof createEvidence>[0][]): ReturnType<typeof advanceShotIntentState>[] => {
+  const results: ReturnType<typeof advanceShotIntentState>[] = [];
+  let state: ShotIntentState | undefined;
+
+  for (const step of steps) {
+    const result = advanceShotIntentState(state, createEvidence(step));
+    results.push(result);
+    state = result.state;
+  }
+
+  return results;
+};
+
+const canvasSize = { width: 1280, height: 720 };
+
+const createArmedRuntime = (): GameInputFrame["runtime"] => {
+  const openFrame = withThumbTriggerPose(createThumbTriggerFrame("open"), "open");
+  const first = mapHandToGameInput(openFrame, canvasSize, undefined, gameConfig.input);
+  const second = mapHandToGameInput(openFrame, canvasSize, first.runtime, gameConfig.input);
+
+  return second.runtime;
+};
+
+describe("tracking loss", () => {
+  it("drops armed intent on tracking loss and requires a fresh open cycle after recovery", () => {
+    const [
+      first,
+      second,
+      third,
+      fourth,
+      fifth,
+      sixth,
+      seventh,
+      eighth,
+      ninth,
+      tenth,
+      eleventh
+    ] =
+      runSequence([
+        { triggerState: "open" },
+        { triggerState: "open" },
+        { triggerState: "open" },
+        { trackingPresent: false },
+        { triggerState: "open" },
+        { triggerState: "open" },
+        { triggerState: "open" },
+        { triggerState: "open" },
+        { triggerState: "open" },
+        { triggerState: "pulled" },
+        { triggerState: "pulled" }
+      ]);
+
+    expect(first?.state.phase).toBe("idle");
+    expect(second?.state.phase).toBe("ready");
+    expect(third?.state.phase).toBe("armed");
+    expect(fourth?.state.phase).toBe("tracking_lost");
+    expect(fourth?.shotFired).toBe(false);
+    expect(fifth?.state.phase).toBe("tracking_lost");
+    expect(sixth?.state.phase).toBe("idle");
+    expect(seventh?.state.phase).toBe("ready");
+    expect(eighth?.state.phase).toBe("armed");
+    expect(ninth?.state.phase).toBe("armed");
+    expect(tenth?.state.phase).toBe("armed");
+    expect(eleventh?.state.phase).toBe("fired");
+    expect(eleventh?.shotFired).toBe(true);
+  });
+
+  it("turns missing tracking into tracking_lost and clears the crosshair", () => {
+    const result = mapHandToGameInput(undefined, canvasSize, createArmedRuntime());
+
+    expect(result.runtime.phase).toBe("tracking_lost");
+    expect(result.runtime.rejectReason).toBe("tracking_lost");
+    expect(result.shotFired).toBe(false);
+    expect(result.crosshair).toBeUndefined();
+    expect(result.runtime.crosshair).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #30

## Summary
- redesign the finger-gun input path around explicit hand-evidence and shot-intent state transitions
- add debug telemetry and deterministic browser coverage for one-shot, hold, jitter, and tracking-loss recovery scenarios
- align README and implementation handoff docs with the thumb-trigger-only issue-30 contract

## Test Plan
- [x] npm run lint
- [x] npm run typecheck
- [x] npm run test
- [x] npm run test:e2e
- [x] npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 実行時デバッグパネルにテレメトリ表示とデバッグフックを追加、フェーズ・信頼度・カウンタを可視化。
  * 手入力からの安定した狙点算出、サムトリガーの信頼度測定、ガンポーズ測定、発射意図制御（単発・非連射・ジッター抑止・追跡喪失/再取得）を導入。

* **リファクタ**
  * 入力マッピングと意図判定を再設計し、クロスヘア／ランタイム状態の扱いを簡潔化。

* **ドキュメント**
  * README と実装ハンドオフを「実装済み／サムトリガー」に更新。

* **テスト**
  * E2E とユニットを大幅拡充し、発火シナリオ・追跡喪失・テレメトリの検証を追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->